### PR TITLE
Add codex_lite package skeleton

### DIFF
--- a/codex_lite/__init__.py
+++ b/codex_lite/__init__.py
@@ -1,0 +1,8 @@
+"""Pacote Codex-Lite."""
+from importlib import metadata as _metadata
+
+__version__: str = _metadata.version(__name__)
+
+from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __version__
+
+__all__ = ["Agent", "run_interactive"]

--- a/codex_lite/agent.py
+++ b/codex_lite/agent.py
@@ -1,0 +1,68 @@
+"""Camada de orquestração: recebe mensagens, chama OpenAI, delega ferramentas."""
+
+import json
+import os
+import pathlib
+import uuid
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import openai
+from rich.console import Console
+from rich.panel import Panel
+
+from .runtime import Runtime
+from .tools import TOOL_SCHEMAS, execute_tool
+
+MODEL = os.getenv("CODEX_LITE_MODEL", "gpt-4o-mini-preview")
+SYSTEM_MSG = (
+    "You are Codex-Lite, a sandboxed coding assistant.\n"
+    "Respond with JSON when you need to use a tool."
+)
+
+console = Console()
+
+
+def _chat(messages: List[Dict[str, str]]) -> str:
+    resp = openai.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        tools=TOOL_SCHEMAS,
+        tool_choice="auto",
+    )
+    return resp.choices[0].message
+
+
+@dataclass
+class Agent:
+    runtime: Runtime = field(default_factory=Runtime)
+    history: List[Dict[str, Any]] = field(default_factory=lambda: [
+        {"role": "system", "content": SYSTEM_MSG}
+    ])
+
+    def step(self, user_msg: str) -> None:
+        self.history.append({"role": "user", "content": user_msg})
+        assistant_msg = _chat(self.history)
+        self.history.append(assistant_msg)
+
+        if assistant_msg.tool_calls:
+            for call in assistant_msg.tool_calls:
+                output = execute_tool(call, self.runtime)
+                self.history.append({"role": "tool", "content": output, "tool_call_id": call.id})
+                console.print(Panel(output, title=f"tool:{call.function.name}"))
+        else:
+            console.print(assistant_msg.content)
+
+
+def run_interactive() -> None:  # pragma: no cover
+    agent = Agent()
+    console.print("[bold green]Codex-Lite[/] iniciado. (digite /exit para sair)")
+    try:
+        while True:
+            user_msg = console.input("[cyan]vc> [/]" )
+            if user_msg.strip() in {"/exit", "quit", "q"}:
+                break
+            agent.step(user_msg)
+    finally:
+        agent.runtime.cleanup()

--- a/codex_lite/cli.py
+++ b/codex_lite/cli.py
@@ -1,0 +1,5 @@
+"""Console-entry para clite."""
+from .agent import run_interactive
+
+def main() -> None:  # pragma: no cover
+    run_interactive()

--- a/codex_lite/py.typed
+++ b/codex_lite/py.typed
@@ -1,0 +1,1 @@
+"""empty file to indicate PEP-561 typing support"""

--- a/codex_lite/runtime.py
+++ b/codex_lite/runtime.py
@@ -1,0 +1,53 @@
+"""Isola as execuções num container Docker efêmero."""
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Union
+
+import docker
+
+
+class Runtime:
+    """Cada instância corresponde a um diretório + container dedicados."""
+
+    def __init__(self, image: str | None = None) -> None:
+        self.base_dir = Path(tempfile.mkdtemp(prefix="clite_"))
+        self.image = image or os.getenv("CODEX_LITE_IMAGE", "python:3.12-slim")
+        self.client = docker.from_env()
+        self.container = self.client.containers.run(
+            self.image,
+            name=f"clite-{uuid.uuid4().hex[:8]}",
+            command="sleep infinity",
+            volumes={str(self.base_dir): {"bind": "/workspace", "mode": "rw"}},
+            working_dir="/workspace",
+            detach=True,
+            tty=True,
+            network_disabled=True,
+            mem_limit="512m",
+            pids_limit=256,
+        )
+
+    # ---------------- public API ----------------
+    def bash(self, cmd: str, timeout: int = 30) -> str:
+        """Roda comando dentro do container e devolve saída combinada."""
+        res = self.container.exec_run(cmd, workdir="/workspace", demux=True, tty=False, timeout=timeout)
+        stdout, stderr = res.output if isinstance(res.output, tuple) else (res.output, b"")
+        return (stdout or b"").decode() + (stderr or b"").decode()
+
+    def write_file(self, rel_path: Union[str, Path], content: str) -> str:
+        p = self.base_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        return f"Wrote {p.relative_to(self.base_dir)}"
+
+    def cleanup(self) -> None:
+        try:
+            self.container.kill()
+        finally:
+            self.container.remove(force=True)
+            shutil.rmtree(self.base_dir, ignore_errors=True)

--- a/codex_lite/tools.py
+++ b/codex_lite/tools.py
@@ -1,0 +1,50 @@
+"""Mapa de ferramentas disponíveis para o agente."""
+from __future__ import annotations
+import json
+from typing import Any, Dict
+
+from .runtime import Runtime
+
+TOOL_SCHEMAS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command inside the sandboxed container.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cmd": {"type": "string", "description": "Command to execute"}
+                },
+                "required": ["cmd"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "description": "Create or overwrite a file in the workspace.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+]
+
+# --------------- dispatcher ---------------
+
+def execute_tool(call: Any, rt: Runtime) -> str:  # pragma: no cover, Any→openai.types.ToolCall
+    name = call.function.name
+    args: Dict[str, Any] = json.loads(call.function.arguments)
+
+    if name == "bash":
+        return rt.bash(**args)
+    if name == "write_file":
+        return rt.write_file(**args)
+    return f"⚠️ unknown tool {name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "codex_lite"
+version = "0.1.0"
+description = "A minimal agentic coding assistant that runs each task in a secure container."
+authors = [ { name = "Seu Nome", email = "email@example.com" } ]
+requires-python = ">=3.9"
+dependencies = [
+    "openai>=1.0.0",   # interface com modelos da OpenAI
+    "docker>=7.0.0",    # manipular containers
+    "rich>=13.7.0"      # saídas coloridas (opcional)
+]
+
+[project.scripts]
+clite = "codex_lite.cli:main"
+
+[tool.setuptools.package-data]
+"codex_lite" = ["py.typed"]


### PR DESCRIPTION
## Summary
- create `codex_lite` package with runtime, tools and agent
- provide console entry point
- add project metadata in `pyproject.toml`

## Testing
- `python -m py_compile codex_lite/__init__.py codex_lite/cli.py codex_lite/agent.py codex_lite/runtime.py codex_lite/tools.py`


------
https://chatgpt.com/codex/tasks/task_e_685dfa2843c48321b3a8e40c37ac8059