### PR TITLE
Fix docs deploy permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python


### PR DESCRIPTION
## Summary
- allow `docs` workflow to push to `gh-pages`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e22993cd88321a64509099dbb15e4