### PR TITLE
Configure OIDC permission for PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- grant the `release` job permission to request ID tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e255fa19c8321903b42dc73420ba6