### PR TITLE
Fix PyPI build metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ docs = ["mkdocs"]
 
 [tool.setuptools.package-data]
 "pygent" = ["py.typed"]
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- include build-system requirements in `pyproject.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e26cbe1a48321a568c90d3936672f