### PR TITLE
Add docs for API reference and getting started

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,34 @@
+# API Reference
+
+This section summarises the most relevant classes and functions.
+
+## `Agent`
+
+```python
+from pygent import Agent
+```
+
+The main entry point for interacting with Pygent. It keeps a conversation history and exposes a `step()` method to process user messages. Tool calls are automatically executed and their output appended to the history. Each `Agent` owns a `Runtime` instance stored in `agent.runtime`.
+
+### `Agent.step(user_msg: str) -> None`
+Adds the message to the conversation, queries the model and prints any tool output.
+
+### `run_interactive(use_docker: bool | None = None) -> None`
+Launches an interactive shell similar to the command line interface.
+
+## `Runtime`
+
+Handles command execution either in a Docker container or locally. Important methods include:
+
+- `bash(cmd: str, timeout: int = 30) -> str` &ndash; run a shell command and return its combined output.
+- `write_file(path: str, content: str) -> str` &ndash; create or replace a file inside the working directory.
+- `cleanup() -> None` &ndash; destroy the temporary workspace and stop the container if used.
+
+## Tools
+
+The agent can call two built-in tools:
+
+- **bash** &ndash; executes shell commands via `Runtime.bash`.
+- **write_file** &ndash; writes files through `Runtime.write_file`.
+
+Refer to the `tools.py` module for the implementation details.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,39 @@
+# Getting Started
+
+This tutorial shows how to install Pygent and run a few basic commands. It also demonstrates how to use the Python API directly.
+
+## Installation
+
+Install from source in editable mode so the command line and Python modules are available:
+
+```bash
+pip install -e .[docker]
+```
+
+Docker is optional. If it is not available omit the `[docker]` extras and commands will run locally.
+
+## Interactive session
+
+Start the CLI by running `pygent`. Type normal instructions and each command will be executed in a sandboxed environment.
+
+```bash
+$ pygent --docker
+vc> echo "Hello"
+```
+
+Use `/exit` to leave the session.
+
+## Using the API
+
+The `Agent` class exposes the same functionality programmatically. Here is a minimal example:
+
+```python
+from pygent import Agent
+
+ag = Agent()
+ag.step("echo 'Hello World'")
+# additional steps...
+ag.runtime.cleanup()
+```
+
+Check the `examples/` directory for more advanced scripts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 Pygent is a minimal coding assistant that runs tasks inside an isolated Docker container whenever available. If Docker is not configured the commands run locally. This manual summarises the main commands and configuration options.
 
+See [Getting Started](getting-started.md) for a quick tutorial or jump to the [API Reference](api-reference.md) for details about the available classes.
+
 ## Installation
 
 ```bash
@@ -28,4 +30,3 @@ ag.runtime.cleanup()
 Install optional dependencies with `pip install -e .[test,docs]` and run `pytest` to execute the tests. Use `mkdocs serve` to build this documentation locally.
 
 See the README file for more detailed information.
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Pygent
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - API Reference: api-reference.md
 site_url: https://example.com/
 repo_url: https://github.com/marianochaves/pygent


### PR DESCRIPTION
## Summary
- document a quick start tutorial
- add an API reference page
- link new pages from the home page and update MkDocs nav

## Testing
- `pytest -q`
- ❌ `mkdocs build -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1e4dc64c832185f51abd0d69942a