### PR TITLE
Add OpenAI configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ To run commands in Docker containers also install `pygent[docker]`.
 Behaviour can be adjusted via environment variables:
 
 * `OPENAI_API_KEY` &ndash; key used to access the OpenAI API.
+  Set this to your API key or a key from any compatible provider.
+* `OPENAI_BASE_URL` &ndash; base URL for OpenAI-compatible APIs
+  (defaults to ``https://api.openai.com/v1``).
 * `PYGENT_MODEL` &ndash; model name used for requests (default `gpt-4o-mini-preview`).
 * `PYGENT_IMAGE` &ndash; Docker image to create the container (default `python:3.12-slim`).
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
@@ -58,6 +61,22 @@ ag.runtime.cleanup()
 ```
 
 See the `examples/` folder for more complete scripts.
+
+### Using OpenAI and other providers
+
+Set your OpenAI key:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+To use a different provider, set `OPENAI_BASE_URL` to the provider
+endpoint and keep `OPENAI_API_KEY` pointing to the correct key:
+
+```bash
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+export OPENAI_API_KEY="your-provider-key"
+```
 
 ## Development
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,21 +8,28 @@ This section summarises the most relevant classes and functions.
 from pygent import Agent
 ```
 
-The main entry point for interacting with Pygent. It keeps a conversation history and exposes a `step()` method to process user messages. Tool calls are automatically executed and their output appended to the history. Each `Agent` owns a `Runtime` instance stored in `agent.runtime`.
+Manages the conversation with the model. Each instance owns a
+`Runtime` accessible via ``agent.runtime``.
 
-### `Agent.step(user_msg: str) -> None`
-Adds the message to the conversation, queries the model and prints any tool output.
+**Methods**
 
-### `run_interactive(use_docker: bool | None = None) -> None`
-Launches an interactive shell similar to the command line interface.
+- `step(user_msg: str) -> None` – add a message, run tools and print
+  their output.
+- `run_interactive(use_docker: bool | None = None) -> None` – start an
+  interactive session.
 
 ## `Runtime`
 
-Handles command execution either in a Docker container or locally. Important methods include:
+Executes commands either in a Docker container or locally.
 
-- `bash(cmd: str, timeout: int = 30) -> str` &ndash; run a shell command and return its combined output.
-- `write_file(path: str, content: str) -> str` &ndash; create or replace a file inside the working directory.
-- `cleanup() -> None` &ndash; destroy the temporary workspace and stop the container if used.
+**Methods**
+
+- `bash(cmd: str, timeout: int = 30) -> str` – run a shell command and
+  return its output.
+- `write_file(path: str, content: str) -> str` – create or replace a
+  file in the working directory.
+- `cleanup() -> None` – destroy the temporary workspace and stop the
+  container if used.
 
 ## Tools
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,3 +37,20 @@ ag.runtime.cleanup()
 ```
 
 Check the `examples/` directory for more advanced scripts.
+
+## Model configuration
+
+Pygent communicates with the model through an OpenAI-compatible API.
+Set your key via the ``OPENAI_API_KEY`` environment variable:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+To use a different provider, set ``OPENAI_BASE_URL`` to the provider's
+endpoint and keep ``OPENAI_API_KEY`` pointing to its key:
+
+```bash
+export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
+export OPENAI_API_KEY="your-provider-key"
+```

--- a/examples/api_example.py
+++ b/examples/api_example.py
@@ -1,5 +1,17 @@
-"""Simple example of using Pygent via the API."""
+"""Simple example of using Pygent via the API.
+
+The agent expects an OpenAI-compatible backend. Set the
+``OPENAI_API_KEY`` environment variable to your API key. To use a
+provider other than OpenAI, also set ``OPENAI_BASE_URL`` with the
+provider's endpoint.
+"""
+
+import os
 from pygent import Agent
+
+# Uncomment and fill in your credentials:
+# os.environ["OPENAI_API_KEY"] = "sk-..."
+# os.environ["OPENAI_BASE_URL"] = "https://other-provider.example.com/v1"
 
 ag = Agent()
 ag.step("echo 'Hello World'")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,10 @@
 site_name: Pygent
+site_url: https://example.com/
+repo_url: https://github.com/marianochaves/pygent
+theme: readthedocs
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - API Reference: api-reference.md
-site_url: https://example.com/
-repo_url: https://github.com/marianochaves/pygent
+plugins:
+  - search


### PR DESCRIPTION
## Summary
- add tips for using Pygent with OpenAI and other providers
- show environment variables in the quickstart docs and README
- update the API example to demonstrate setting OpenAI-compatible credentials
- switch the docs site to the `readthedocs` theme and tidy the API reference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f20d793508321bea763fb18898e77