### PR TITLE
Add minimal web UI and update model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Integrates with OpenAI-compatible models to orchestrate each step.
 * Persists the conversation history during the session.
 * Provides a small Python API for use in other projects.
+* Optional web interface via `pygent-ui`.
 
 ## Installation
 
@@ -29,7 +30,7 @@ Behaviour can be adjusted via environment variables:
   Set this to your API key or a key from any compatible provider.
 * `OPENAI_BASE_URL` &ndash; base URL for OpenAI-compatible APIs
   (defaults to ``https://api.openai.com/v1``).
-* `PYGENT_MODEL` &ndash; model name used for requests (default `gpt-4o-mini-preview`).
+* `PYGENT_MODEL` &ndash; model name used for requests (default `gpt-4.1-mini`).
 * `PYGENT_IMAGE` &ndash; Docker image to create the container (default `python:3.12-slim`).
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
 
@@ -45,7 +46,10 @@ Use `--docker` to run commands inside a container (requires
 `pygent[docker]`). Use `--no-docker` or set `PYGENT_USE_DOCKER=0`
 to force local execution.
 
-Type messages normally; use `/exit` to end the session. Each command is executed in the container and the result shown in the terminal.
+Type messages normally; use `/exit` to end the session. Each command is executed
+in the container and the result shown in the terminal.
+For a minimal web interface run `pygent-ui` instead (requires `pygent[ui]`).
+
 
 ## API usage
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,6 +17,8 @@ Manages the conversation with the model. Each instance owns a
   their output.
 - `run_interactive(use_docker: bool | None = None) -> None` – start an
   interactive session.
+- `run_gui(use_docker: bool | None = None) -> None` – start a simple
+  web interface.
 
 ## `Runtime`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,8 @@ vc> echo "Hello"
 ```
 
 Use `/exit` to leave the session.
+Alternatively, run `pygent-ui` for a small web interface (requires
+`pygent[ui]`).
 
 ## Using the API
 
@@ -40,8 +42,10 @@ Check the `examples/` directory for more advanced scripts.
 
 ## Model configuration
 
-Pygent communicates with the model through an OpenAI-compatible API.
-Set your key via the ``OPENAI_API_KEY`` environment variable:
+Pygent communicates with the model through an OpenAI-compatible API. The
+default model is ``gpt-4.1-mini``; override it by setting the
+``PYGENT_MODEL`` environment variable. Set your key via the
+``OPENAI_API_KEY`` environment variable:
 
 ```bash
 export OPENAI_API_KEY="sk-..."

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,12 @@ See [Getting Started](getting-started.md) for a quick tutorial or jump to the [A
 pip install -e .
 ```
 
-Python ≥ 3.9 is required. Docker is optional; install `pygent[docker]` to enable container execution. Adjust the `OPENAI_API_KEY`, `PYGENT_MODEL`, `PYGENT_IMAGE` and `PYGENT_USE_DOCKER` variables as needed.
+Python ≥ 3.9 is required. Docker is optional; install `pygent[docker]` to enable container execution. Adjust the `OPENAI_API_KEY`, `PYGENT_MODEL`, `PYGENT_IMAGE` and `PYGENT_USE_DOCKER` variables as needed. By default the assistant uses the `gpt-4.1-mini` model.
 
 ## Basic usage
 
 Start an interactive session by running `pygent` in the terminal. Use the `--docker` option to run commands in a container (requires `pygent[docker]`); otherwise they execute locally. Use `/exit` to quit.
+Alternatively run `pygent-ui` for a simple web interface (requires `pygent[ui]`).
 
 You can also use the Python API:
 

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -18,7 +18,7 @@ from rich.panel import Panel
 from .runtime import Runtime
 from .tools import TOOL_SCHEMAS, execute_tool
 
-MODEL = os.getenv("PYGENT_MODEL", "gpt-4o-mini-preview")
+MODEL = os.getenv("PYGENT_MODEL", "gpt-4.1-mini")
 SYSTEM_MSG = (
     "You are Pygent, a sandboxed coding assistant.\n"
     "Respond with JSON when you need to use a tool."

--- a/pygent/ui.py
+++ b/pygent/ui.py
@@ -1,0 +1,36 @@
+from .agent import Agent, _chat
+from .runtime import Runtime
+from .tools import execute_tool
+
+
+def run_gui(use_docker: bool | None = None) -> None:
+    """Launch a simple Gradio chat interface."""
+    try:
+        import gradio as gr
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional
+        raise SystemExit(
+            "Gradio is required for the GUI. Install with 'pip install pygent[ui]'"
+        ) from exc
+
+    agent = Agent(runtime=Runtime(use_docker=use_docker))
+
+    def _respond(message: str, history: list[tuple[str, str]] | None) -> str:
+        agent.history.append({"role": "user", "content": message})
+        assistant_msg = _chat(agent.history)
+        agent.history.append(assistant_msg)
+        reply = assistant_msg.content or ""
+        if assistant_msg.tool_calls:
+            for call in assistant_msg.tool_calls:
+                output = execute_tool(call, agent.runtime)
+                agent.history.append({"role": "tool", "content": output, "tool_call_id": call.id})
+                reply += f"\n\n[tool:{call.function.name}]\n{output}"
+        return reply
+
+    try:
+        gr.ChatInterface(_respond, title="Pygent").launch()
+    finally:
+        agent.runtime.cleanup()
+
+
+def main() -> None:  # pragma: no cover
+    run_gui()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ llm = ["openai>=1.0.0"]  # OpenAI-compatible library (optional)
 test = ["pytest"]
 docs = ["mkdocs"]
 docker = ["docker>=7.0.0"]
+ui = ["gradio"]
 
 [project.urls]
 Documentation = "https://marianochaves.github.io/pygent"
@@ -20,6 +21,7 @@ Repository = "https://github.com/marianochaves/pygent"
 
 [project.scripts]
 pygent = "pygent.cli:main"
+pygent-ui = "pygent.ui:main"
 
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.2"
+version = "0.1.3"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- update default model to `gpt-4.1-mini`
- add optional Gradio UI with `pygent-ui` entrypoint
- document the new interface and model defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f245a50ac832182348e1423c6011a