### PR TITLE
Implement pluggable model interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ ag.step("echo 'Hello World'")
 ag.runtime.cleanup()
 ```
 
-See the `examples/` folder for more complete scripts.
+See the `examples/` folder for more complete scripts. Models can be swapped by
+passing an object implementing the ``Model`` interface when creating the
+``Agent``. The default uses an OpenAI-compatible API, but custom models are
+easy to plug in.
 
 ### Using OpenAI and other providers
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -41,3 +41,10 @@ The agent can call two built-in tools:
 - **write_file** &ndash; writes files through `Runtime.write_file`.
 
 Refer to the `tools.py` module for the implementation details.
+
+## Custom models
+
+The `Agent` relies on a model object with a ``chat`` method. The default is
+``OpenAIModel`` which calls an OpenAI-compatible API. To plug in a different
+backend, implement the ``Model`` protocol and pass an instance when creating the
+agent.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,3 +58,7 @@ endpoint and keep ``OPENAI_API_KEY`` pointing to its key:
 export OPENAI_BASE_URL="https://openrouter.ai/api/v1"
 export OPENAI_API_KEY="your-provider-key"
 ```
+
+For complete control you can also supply a custom model implementation. Create a
+class with a ``chat(messages, model, tools)`` method and pass an instance to
+``Agent``.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,9 @@ ag.step("echo test")
 ag.runtime.cleanup()
 ```
 
+Custom models are supported by implementing the ``Model`` protocol and passing
+the instance to ``Agent``.
+
 ## Development
 
 Install optional dependencies with `pip install -e .[test,docs]` and run `pytest` to execute the tests. Use `mkdocs serve` to build this documentation locally.

--- a/examples/custom_model.py
+++ b/examples/custom_model.py
@@ -1,0 +1,16 @@
+"""Example of using a custom model with Pygent."""
+
+from pygent import Agent, openai_compat
+
+
+class EchoModel:
+    """A trivial model that echoes the last user message."""
+
+    def chat(self, messages, model, tools):
+        last = messages[-1]["content"]
+        return openai_compat.Message(role="assistant", content=f"Echo: {last}")
+
+
+ag = Agent(model=EchoModel())
+ag.step("test")
+ag.runtime.cleanup()

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -7,5 +7,6 @@ except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
     __version__ = "0.0.0"
 
 from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __version__
+from .models import Model, OpenAIModel  # noqa: E402,F401
 
-__all__ = ["Agent", "run_interactive"]
+__all__ = ["Agent", "run_interactive", "Model", "OpenAIModel"]

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -8,17 +8,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
-try:
-    import openai  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - fallback to bundled client
-    from . import openai_compat as openai
 from rich.console import Console
 from rich.panel import Panel
 
 from .runtime import Runtime
 from .tools import TOOL_SCHEMAS, execute_tool
+from .models import Model, OpenAIModel
 
-MODEL = os.getenv("PYGENT_MODEL", "gpt-4.1-mini")
+DEFAULT_MODEL = os.getenv("PYGENT_MODEL", "gpt-4.1-mini")
 SYSTEM_MSG = (
     "You are Pygent, a sandboxed coding assistant.\n"
     "Respond with JSON when you need to use a tool."
@@ -27,26 +24,20 @@ SYSTEM_MSG = (
 console = Console()
 
 
-def _chat(messages: List[Dict[str, str]]) -> str:
-    resp = openai.chat.completions.create(
-        model=MODEL,
-        messages=messages,
-        tools=TOOL_SCHEMAS,
-        tool_choice="auto",
-    )
-    return resp.choices[0].message
 
 
 @dataclass
 class Agent:
     runtime: Runtime = field(default_factory=Runtime)
+    model: Model = field(default_factory=OpenAIModel)
+    model_name: str = DEFAULT_MODEL
     history: List[Dict[str, Any]] = field(default_factory=lambda: [
         {"role": "system", "content": SYSTEM_MSG}
     ])
 
     def step(self, user_msg: str) -> None:
         self.history.append({"role": "user", "content": user_msg})
-        assistant_msg = _chat(self.history)
+        assistant_msg = self.model.chat(self.history, self.model_name, TOOL_SCHEMAS)
         self.history.append(assistant_msg)
 
         if assistant_msg.tool_calls:

--- a/pygent/models.py
+++ b/pygent/models.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Model interface and default implementation for OpenAI-compatible APIs."""
+
+from typing import Any, Dict, List, Protocol
+
+try:
+    import openai  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback to bundled client
+    from . import openai_compat as openai
+
+from .openai_compat import Message
+
+
+class Model(Protocol):
+    """Protocol for chat models used by :class:`~pygent.agent.Agent`."""
+
+    def chat(self, messages: List[Dict[str, Any]], model: str, tools: Any) -> Message:
+        """Return the assistant message for the given prompt."""
+        ...
+
+
+class OpenAIModel:
+    """Default model using the OpenAI-compatible API."""
+
+    def chat(self, messages: List[Dict[str, Any]], model: str, tools: Any) -> Message:
+        resp = openai.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+        )
+        return resp.choices[0].message

--- a/pygent/ui.py
+++ b/pygent/ui.py
@@ -1,6 +1,6 @@
-from .agent import Agent, _chat
+from .agent import Agent
 from .runtime import Runtime
-from .tools import execute_tool
+from .tools import execute_tool, TOOL_SCHEMAS
 
 
 def run_gui(use_docker: bool | None = None) -> None:
@@ -16,7 +16,7 @@ def run_gui(use_docker: bool | None = None) -> None:
 
     def _respond(message: str, history: list[tuple[str, str]] | None) -> str:
         agent.history.append({"role": "user", "content": message})
-        assistant_msg = _chat(agent.history)
+        assistant_msg = agent.model.chat(agent.history, agent.model_name, TOOL_SCHEMAS)
         agent.history.append(assistant_msg)
         reply = assistant_msg.content or ""
         if assistant_msg.tool_calls:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod = types.ModuleType('panel')
+panel_mod.Panel = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent, openai_compat
+
+class DummyModel:
+    def chat(self, messages, model, tools):
+        return openai_compat.Message(role='assistant', content='ok')
+
+
+def test_custom_model():
+    ag = Agent(model=DummyModel())
+    ag.step('hi')
+    assert ag.history[-1].content == 'ok'


### PR DESCRIPTION
## Summary
- create new `Model` protocol and `OpenAIModel` default implementation
- refactor `Agent` and GUI to use the new model interface
- document how to create custom models
- provide example `examples/custom_model.py`
- bump version to 0.1.4
- add tests for the custom model interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f278691008321930dfbcaa5b249e3