### PR TITLE
Include openai dependency and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Installing from source is recommended:
 pip install -e .
 ```
 
-Python ≥ 3.9 is required. The only runtime dependency is `rich`.
-Install any OpenAI-compatible library such as `openai` or `litellm` separately to enable model access.
+Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
 To run commands in Docker containers also install `pygent[docker]`.
 
 ## Configuration

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ Install from source in editable mode so the CLI and Python modules are
 available. Include the optional extras to enable Docker support and the web UI:
 
 ```bash
-pip install pygent[llm,docker,ui]
+pip install pygent[docker,ui]
 ```
 
 Python 3.9 or newer is required. If Docker is not installed omit the

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -35,7 +35,7 @@ class Agent:
         {"role": "system", "content": SYSTEM_MSG}
     ])
 
-    def step(self, user_msg: str) -> None:
+    def step(self, user_msg: str):
         self.history.append({"role": "user", "content": user_msg})
         assistant_msg = self.model.chat(self.history, self.model_name, TOOL_SCHEMAS)
         self.history.append(assistant_msg)
@@ -47,6 +47,18 @@ class Agent:
                 console.print(Panel(output, title=f"tool:{call.function.name}"))
         else:
             console.print(assistant_msg.content)
+        return assistant_msg
+
+    def run_until_stop(self, user_msg: str, max_steps: int = 10) -> None:
+        """Run steps automatically until the model calls the ``stop`` tool or
+        the step limit is reached."""
+        msg = user_msg
+        for _ in range(max_steps):
+            assistant_msg = self.step(msg)
+            calls = assistant_msg.tool_calls or []
+            if any(c.function.name == "stop" for c in calls):
+                break
+            msg = "continue"
 
 
 def run_interactive(use_docker: bool | None = None) -> None:  # pragma: no cover

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -35,6 +35,14 @@ TOOL_SCHEMAS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "stop",
+            "description": "Stop the autonomous loop.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
 ]
 
 # --------------- dispatcher ---------------
@@ -47,4 +55,6 @@ def execute_tool(call: Any, rt: Runtime) -> str:  # pragma: no cover, Any→open
         return rt.bash(**args)
     if name == "write_file":
         return rt.write_file(**args)
+    if name == "stop":
+        return "Stopping."
     return f"⚠️ unknown tool {name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "pygent"
-version = "0.1.5"
+version = "0.1.6"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"
 dependencies = [
-    "rich>=13.7.0"      # colored output (optional)
+    "rich>=13.7.0",      # colored output (optional)
+    "openai>=1.0.0",
 ]
 
 [project.optional-dependencies]
-llm = ["openai>=1.0.0"]  # OpenAI-compatible library (optional)
 test = ["pytest"]
 docs = ["mkdocs"]
 docker = ["docker>=7.0.0"]

--- a/tests/test_autorun.py
+++ b/tests/test_autorun.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod = types.ModuleType('panel')
+panel_mod.Panel = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent, openai_compat
+
+class DummyModel:
+    def __init__(self):
+        self.count = 0
+    def chat(self, messages, model, tools):
+        self.count += 1
+        if self.count == 1:
+            return openai_compat.Message(
+                role='assistant',
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id='1',
+                        type='function',
+                        function=openai_compat.ToolCallFunction(
+                            name='bash',
+                            arguments='{"cmd": "ls"}'
+                        )
+                    )
+                ]
+            )
+        else:
+            return openai_compat.Message(
+                role='assistant',
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id='2',
+                        type='function',
+                        function=openai_compat.ToolCallFunction(
+                            name='stop',
+                            arguments='{}'
+                        )
+                    )
+                ]
+            )
+
+class DummyRuntime:
+    def bash(self, cmd: str):
+        return f"ran {cmd}"
+    def write_file(self, path: str, content: str):
+        return f"wrote {path}"
+
+
+def test_run_until_stop():
+    ag = Agent(runtime=DummyRuntime(), model=DummyModel())
+    ag.run_until_stop('start', max_steps=5)
+    assert any(call.function.name == 'stop'
+               for msg in ag.history
+               if hasattr(msg, 'tool_calls') and msg.tool_calls
+               for call in msg.tool_calls)


### PR DESCRIPTION
## Summary
- depend on the `openai` package by default
- remove the `[llm]` extra
- update docs to reflect the new dependency
- bump version to 0.1.6

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f4a0623cc8321bbe34394014c7fb3