### PR TITLE
Fix Runtime.write_file parameter

### DIFF
--- a/pygent/runtime.py
+++ b/pygent/runtime.py
@@ -71,8 +71,8 @@ class Runtime:
         )
         return proc.stdout + proc.stderr
 
-    def write_file(self, rel_path: Union[str, Path], content: str) -> str:
-        p = self.base_dir / rel_path
+    def write_file(self, path: Union[str, Path], content: str) -> str:
+        p = self.base_dir / path
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content)
         return f"Wrote {p.relative_to(self.base_dir)}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.6"
+version = "0.1.7"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- fix `Runtime.write_file` to use `path` argument as documented

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4dc8fb9c8321b2341018b7d8b112