### PR TITLE
Improve docs structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pygent
 
-Pygent is a coding assistant that executes each request inside an isolated Docker container whenever possible. If Docker is unavailable (for instance on some Windows setups) the commands are executed locally instead.
+Pygent is a coding assistant that executes each request inside an isolated Docker container whenever possible. If Docker is unavailable (for instance on some Windows setups) the commands are executed locally instead. Full documentation is available in the `docs/` directory and at the project site.
 
 ## Features
 
@@ -23,7 +23,7 @@ To run commands in Docker containers also install `pygent[docker]`.
 
 ## Configuration
 
-Behaviour can be adjusted via environment variables:
+Behaviour can be adjusted via environment variables (see `docs/configuration.md` for a complete list):
 
 * `OPENAI_API_KEY` &ndash; key used to access the OpenAI API.
   Set this to your API key or a key from any compatible provider.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pygent
 
-Pygent is a coding assistant that executes each request inside an isolated Docker container whenever possible. If Docker is unavailable (for instance on some Windows setups) the commands are executed locally instead. Full documentation is available in the `docs/` directory and at the project site.
+Pygent is a coding assistant that executes each request inside an isolated Docker container whenever possible. If Docker is unavailable (for instance on some Windows setups) the commands are executed locally instead. Full documentation is available in the `docs/` directory and at [marianochaves.github.io/pygent](https://marianochaves.github.io/pygent/).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ag.step("echo 'Hello World'")
 ag.runtime.cleanup()
 ```
 
-See the `examples/` folder for more complete scripts. Models can be swapped by
+See the [examples](https://github.com/marianochaves/pygent/tree/main/examples) folder for more complete scripts. Models can be swapped by
 passing an object implementing the ``Model`` interface when creating the
 ``Agent``. The default uses an OpenAI-compatible API, but custom models are
 easy to plug in.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,15 @@
+# Configuration
+
+This page summarises the environment variables that control Pygent.  They can be
+exported in your shell or set via a `.env` file before running the CLI.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for OpenAI or any compatible service. | – |
+| `OPENAI_BASE_URL` | Base URL for the API endpoint. | `https://api.openai.com/v1` |
+| `PYGENT_MODEL` | Model name used for requests. | `gpt-4.1-mini` |
+| `PYGENT_IMAGE` | Docker image used for sandboxed execution. | `python:3.12-slim` |
+| `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
+
+See [Getting Started](getting-started.md) for installation instructions and the
+[API Reference](api-reference.md) for details about the available classes.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,10 @@
+# Examples
+
+This page collects small scripts demonstrating different aspects of Pygent. Each link points to the source file on GitHub.
+
+- [api_example.py](https://github.com/marianochaves/pygent/blob/main/examples/api_example.py) &ndash; minimal use of the :class:`~pygent.agent.Agent` API.
+- [runtime_example.py](https://github.com/marianochaves/pygent/blob/main/examples/runtime_example.py) &ndash; using the :class:`~pygent.runtime.Runtime` class directly.
+- [write_file_demo.py](https://github.com/marianochaves/pygent/blob/main/examples/write_file_demo.py) &ndash; calling the built-in tools from Python code.
+- [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) &ndash; implementing a simple custom model.
+
+Run these with `python <script>` from the project root. They expect the environment variables described in the [Configuration](configuration.md) page.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,9 +54,9 @@ ag.step("echo 'Hello World'")
 ag.runtime.cleanup()
 ```
 
-See `examples/api_example.py` for a complete script. Additional examples show
-how to implement a custom model and how to interact with the `Runtime` class
-directly.
+See [api_example.py](https://github.com/marianochaves/pygent/blob/main/examples/api_example.py)
+for a complete script. Additional examples show how to implement a custom model
+and how to interact with the `Runtime` class directly.
 
 ## Configuration
 
@@ -65,12 +65,13 @@ API key before running the assistant. A full list of environment variables is
 available in the [Configuration](configuration.md) page.
 
 For full control you may pass a custom model implementation to `Agent`. The file
-`examples/custom_model.py` contains a minimal echo model example.
+[custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py)
+contains a minimal echo model example.
 
 ## Additional examples
 
 Several scripts in the `examples/` directory showcase different parts of the
-package:
+package (see the dedicated [Examples](examples.md) page):
 
 - **api_example.py** &ndash; minimal use of the :class:`~pygent.agent.Agent` API.
 - **runtime_example.py** &ndash; running commands through the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,19 +60,12 @@ directly.
 
 ## Configuration
 
-Pygent talks to the language model through an OpenAI‑compatible API. Set your
-credentials as environment variables:
+Pygent communicates with the model through an OpenAI‑compatible API. Export your
+API key before running the assistant. A full list of environment variables is
+available in the [Configuration](configuration.md) page.
 
-```bash
-export OPENAI_API_KEY="sk-..."
-export OPENAI_BASE_URL="https://api.openai.com/v1"  # change if using another provider
-```
-
-The model can be changed with `PYGENT_MODEL` and the Docker image with
-`PYGENT_IMAGE`. Set `PYGENT_USE_DOCKER=0` to always disable containers.
-
-For full control you may pass a custom model implementation to `Agent`. The
-file `examples/custom_model.py` contains a minimal echo model example.
+For full control you may pass a custom model implementation to `Agent`. The file
+`examples/custom_model.py` contains a minimal echo model example.
 
 ## Additional examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Pygent
 
-Pygent is a minimal coding assistant that runs tasks inside an isolated Docker container whenever available. If Docker is not configured the commands run locally. This manual summarises the main commands and configuration options.
+Pygent is a minimal coding assistant that runs tasks inside an isolated Docker container whenever available. If Docker is not configured the commands run locally. This manual summarises the main commands and configuration options. See [Configuration](configuration.md) for a list of environment variables.
 
 See [Getting Started](getting-started.md) for a quick tutorial or jump to the [API Reference](api-reference.md) for details about the available classes.
 
@@ -10,7 +10,7 @@ See [Getting Started](getting-started.md) for a quick tutorial or jump to the [A
 pip install pygent
 ```
 
-Python ≥ 3.9 is required. Docker is optional; install `pygent[docker]` to enable container execution. Adjust the `OPENAI_API_KEY`, `PYGENT_MODEL`, `PYGENT_IMAGE` and `PYGENT_USE_DOCKER` variables as needed. By default the assistant uses the `gpt-4.1-mini` model.
+Python ≥ 3.9 is required. Docker is optional; install `pygent[docker]` to enable container execution. The default model is `gpt-4.1-mini`.
 
 ## Basic usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 Pygent is a minimal coding assistant that runs tasks inside an isolated Docker container whenever available. If Docker is not configured the commands run locally. This manual summarises the main commands and configuration options. See [Configuration](configuration.md) for a list of environment variables.
 
+The latest version of this guide is published online at [marianochaves.github.io/pygent](https://marianochaves.github.io/pygent/).
+
 See [Getting Started](getting-started.md) for a quick tutorial or jump to the [API Reference](api-reference.md) for details about the available classes.
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 Pygent is a minimal coding assistant that runs tasks inside an isolated Docker container whenever available. If Docker is not configured the commands run locally. This manual summarises the main commands and configuration options. See [Configuration](configuration.md) for a list of environment variables.
 
 The latest version of this guide is published online at [marianochaves.github.io/pygent](https://marianochaves.github.io/pygent/).
+See the [Examples](examples.md) section for runnable scripts.
 
 See [Getting Started](getting-started.md) for a quick tutorial or jump to the [API Reference](api-reference.md) for details about the available classes.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Configuration: configuration.md
+  - Examples: examples.md
   - API Reference: api-reference.md
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Pygent
-site_url: https://example.com/
+site_url: https://marianochaves.github.io/pygent/
 repo_url: https://github.com/marianochaves/pygent
 theme: readthedocs
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ theme: readthedocs
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Configuration: configuration.md
   - API Reference: api-reference.md
 plugins:
   - search


### PR DESCRIPTION
## Summary
- link to docs site in README
- add a Configuration section to the docs
- reference the new page from the existing guides

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f507bf1588321b4461da5bc50cca3