### PR TITLE
Avoid interactive command hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ to force local execution.
 
 Type messages normally; use `/exit` to end the session. Each command is executed
 in the container and the result shown in the terminal.
+Interactive programs that expect input (e.g. running `python` without a script)
+are not supported and will exit immediately.
 For a minimal web interface run `pygent-ui` instead (requires `pygent[ui]`).
 
 

--- a/pygent/runtime.py
+++ b/pygent/runtime.py
@@ -59,6 +59,7 @@ class Runtime:
                 workdir="/workspace",
                 demux=True,
                 tty=False,
+                stdin=False,
                 timeout=timeout,
             )
             stdout, stderr = (
@@ -72,6 +73,7 @@ class Runtime:
             cwd=self.base_dir,
             capture_output=True,
             text=True,
+            stdin=subprocess.DEVNULL,
             timeout=timeout,
         )
         return f"$ {cmd}\n{proc.stdout + proc.stderr}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.8"
+version = "0.1.9"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- close stdin when running commands
- document that interactive commands like `python` are not supported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5b3844f483219e7df510c6708937