### PR TITLE
Fix UTF-8 handling when writing files

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,7 +29,7 @@ Executes commands either in a Docker container or locally.
 - `bash(cmd: str, timeout: int = 30) -> str` – run a shell command and
   return its output.
 - `write_file(path: str, content: str) -> str` – create or replace a
-  file in the working directory.
+  UTF-8 encoded text file in the working directory.
 - `cleanup() -> None` – destroy the temporary workspace and stop the
   container if used.
 

--- a/pygent/runtime.py
+++ b/pygent/runtime.py
@@ -81,7 +81,7 @@ class Runtime:
     def write_file(self, path: Union[str, Path], content: str) -> str:
         p = self.base_dir / path
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content)
+        p.write_text(content, encoding="utf-8")
         return f"Wrote {p.relative_to(self.base_dir)}"
 
     def cleanup(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.9"
+version = "0.1.10"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- encode files as UTF-8 in `Runtime.write_file`
- document UTF-8 encoding in API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f609ffa508321b2daec80c53e7d83