### PR TITLE
Add custom tools and customizable prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Persists the conversation history during the session.
 * Provides a small Python API for use in other projects.
 * Optional web interface via `pygent-ui`.
+* Register your own tools and customise the system prompt.
 
 ## Installation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,12 +35,39 @@ Executes commands either in a Docker container or locally.
 
 ## Tools
 
-The agent can call two built-in tools:
+Two tools are available by default:
 
 - **bash** &ndash; executes shell commands via `Runtime.bash`.
 - **write_file** &ndash; writes files through `Runtime.write_file`.
 
-Refer to the `tools.py` module for the implementation details.
+Additional tools can be registered programmatically using
+`pygent.register_tool` or the `pygent.tool` decorator. Each tool receives the
+active `Runtime` instance and must return a string.
+
+```python
+from pygent import register_tool
+
+def hello(rt, name: str) -> str:
+    return f"Hello {name}!"
+
+register_tool(
+    "hello",
+    "Greet the user",
+    {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+    hello,
+)
+```
+
+Refer to the `tools.py` module for more details.
+
+## Custom prompts
+
+Pass a custom string to the `Agent` constructor to override the system prompt:
+
+```python
+from pygent import Agent
+ag = Agent(system_msg="You are a friendly bot")
+```
 
 ## Custom models
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,5 +6,6 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [runtime_example.py](https://github.com/marianochaves/pygent/blob/main/examples/runtime_example.py) &ndash; using the :class:`~pygent.runtime.Runtime` class directly.
 - [write_file_demo.py](https://github.com/marianochaves/pygent/blob/main/examples/write_file_demo.py) &ndash; calling the built-in tools from Python code.
 - [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) &ndash; implementing a simple custom model.
+- [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) &ndash; registering a custom tool.
 
 Run these with `python <script>` from the project root. They expect the environment variables described in the [Configuration](configuration.md) page.

--- a/examples/custom_tool.py
+++ b/examples/custom_tool.py
@@ -1,0 +1,17 @@
+"""Demonstrate registering and using a custom tool."""
+from pygent import Agent, register_tool
+
+
+def hello(rt, name: str) -> str:
+    return f"Hello {name}!"
+
+register_tool(
+    "hello",
+    "Greet by name",
+    {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+    hello,
+)
+
+ag = Agent()
+ag.step("hello name='world'")
+ag.runtime.cleanup()

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -9,5 +9,15 @@ except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
 from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __version__
 from .models import Model, OpenAIModel  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
+from .tools import register_tool, tool  # noqa: E402,F401
 
-__all__ = ["Agent", "run_interactive", "Model", "OpenAIModel", "PygentError", "APIError"]
+__all__ = [
+    "Agent",
+    "run_interactive",
+    "Model",
+    "OpenAIModel",
+    "PygentError",
+    "APIError",
+    "register_tool",
+    "tool",
+]

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -1,70 +1,99 @@
-"""Map of tools available to the agent."""
+"""Tool registry and helper utilities."""
 from __future__ import annotations
+
 import json
-from typing import Any, Dict
+from typing import Any, Callable, Dict, List
 
 from .runtime import Runtime
 
-TOOL_SCHEMAS = [
-    {
-        "type": "function",
-        "function": {
-            "name": "bash",
-            "description": "Run a shell command inside the sandboxed container.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "cmd": {"type": "string", "description": "Command to execute"}
-                },
-                "required": ["cmd"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "write_file",
-            "description": "Create or overwrite a file in the workspace.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {"type": "string"},
-                    "content": {"type": "string"},
-                },
-                "required": ["path", "content"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "stop",
-            "description": "Stop the autonomous loop.",
-            "parameters": {"type": "object", "properties": {}},
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "continue",
-            "description": "Continue the conversation.",
-            "parameters": {"type": "object", "properties": {}},
-        },
-    },
-]
 
-# --------------- dispatcher ---------------
+# ---- registry ----
+TOOLS: Dict[str, Callable[..., str]] = {}
+TOOL_SCHEMAS: List[Dict[str, Any]] = []
 
-def execute_tool(call: Any, rt: Runtime) -> str:  # pragma: no cover, Any→openai.types.ToolCall
+
+def register_tool(
+    name: str, description: str, parameters: Dict[str, Any], func: Callable[..., str]
+) -> None:
+    """Register a new callable tool."""
+    if name in TOOLS:
+        raise ValueError(f"tool {name} already registered")
+    TOOLS[name] = func
+    TOOL_SCHEMAS.append(
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": parameters,
+            },
+        }
+    )
+
+
+def tool(name: str, description: str, parameters: Dict[str, Any]):
+    """Decorator for registering a tool."""
+
+    def decorator(func: Callable[..., str]) -> Callable[..., str]:
+        register_tool(name, description, parameters, func)
+        return func
+
+    return decorator
+
+
+def execute_tool(call: Any, rt: Runtime) -> str:  # pragma: no cover
+    """Dispatch a tool call."""
     name = call.function.name
     args: Dict[str, Any] = json.loads(call.function.arguments)
+    func = TOOLS.get(name)
+    if func is None:
+        return f"⚠️ unknown tool {name}"
+    return func(rt, **args)
 
-    if name == "bash":
-        return rt.bash(**args)
-    if name == "write_file":
-        return rt.write_file(**args)
-    if name == "stop":
-        return "Stopping."
-    if name == "continue":
-        return "Continuing the conversation."
-    return f"⚠️ unknown tool {name}"
+
+# ---- built-ins ----
+
+
+@tool(
+    name="bash",
+    description="Run a shell command inside the sandboxed container.",
+    parameters={
+        "type": "object",
+        "properties": {"cmd": {"type": "string", "description": "Command to execute"}},
+        "required": ["cmd"],
+    },
+)
+def _bash(rt: Runtime, cmd: str) -> str:
+    return rt.bash(cmd)
+
+
+@tool(
+    name="write_file",
+    description="Create or overwrite a file in the workspace.",
+    parameters={
+        "type": "object",
+        "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+        "required": ["path", "content"],
+    },
+)
+def _write_file(rt: Runtime, path: str, content: str) -> str:
+    return rt.write_file(path, content)
+
+
+@tool(
+    name="stop",
+    description="Stop the autonomous loop.",
+    parameters={"type": "object", "properties": {}},
+)
+def _stop(rt: Runtime) -> str:  # pragma: no cover - side-effect free
+    return "Stopping."
+
+
+@tool(
+    name="continue",
+    description="Continue the conversation.",
+    parameters={"type": "object", "properties": {}},
+)
+def _continue(rt: Runtime) -> str:  # pragma: no cover - side-effect free
+    return "Continuing the conversation."
+

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -26,7 +26,7 @@ sys.modules.setdefault('rich.syntax', syntax_mod)     # Adicionado
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from pygent import tools
+from pygent import tools, register_tool
 
 class DummyRuntime:
     def bash(self, cmd: str):
@@ -52,4 +52,25 @@ def test_execute_write_file():
         })
     })()
     assert tools.execute_tool(call, DummyRuntime()) == 'wrote foo.txt'
+
+
+def test_register_and_execute_custom_tool():
+    def hello(rt, name: str):
+        return f"hi {name}"
+
+    register_tool(
+        "hello",
+        "greet",
+        {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+        hello,
+    )
+
+    call = type('Call', (), {
+        'function': type('Func', (), {
+            'name': 'hello',
+            'arguments': '{"name": "bob"}'
+        })
+    })()
+    assert tools.execute_tool(call, DummyRuntime()) == 'hi bob'
+
 


### PR DESCRIPTION
## Summary
- enable registration of custom tools via `register_tool` and `tool` decorator
- expose tool registration helpers in package namespace
- allow overriding the agent system prompt
- document custom tools and prompt usage
- provide example script and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686094b7c44c8321ac8d1b20e5c2926b