### PR TITLE
Add task delegation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Behaviour can be adjusted via environment variables (see `docs/configuration.md`
 * `PYGENT_MODEL` &ndash; model name used for requests (default `gpt-4.1-mini`).
 * `PYGENT_IMAGE` &ndash; Docker image to create the container (default `python:3.12-slim`).
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
+* `PYGENT_MAX_TASKS` &ndash; maximum number of concurrent delegated tasks (default `3`).
 
 ## CLI usage
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,10 +35,13 @@ Executes commands either in a Docker container or locally.
 
 ## Tools
 
-Two tools are available by default:
+Several tools are available by default:
 
 - **bash** &ndash; executes shell commands via `Runtime.bash`.
 - **write_file** &ndash; writes files through `Runtime.write_file`.
+- **delegate_task** &ndash; start a background task handled by a new agent.
+- **task_status** &ndash; check the progress of a delegated task.
+- **collect_file** &ndash; copy a file from a delegated task into the current workspace.
 
 Additional tools can be registered programmatically using
 `pygent.register_tool` or the `pygent.tool` decorator. Each tool receives the
@@ -59,6 +62,21 @@ register_tool(
 ```
 
 Refer to the `tools.py` module for more details.
+
+## `TaskManager`
+
+Launch separate agents asynchronously and track them:
+
+```python
+from pygent import TaskManager
+
+tm = TaskManager()
+task_id = tm.start_task("generate report")
+print(tm.status(task_id))
+```
+Delegated agents cannot create further tasks. The maximum number of concurrent
+tasks is controlled by the ``PYGENT_MAX_TASKS`` environment variable (default
+``3``).
 
 ## Custom prompts
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -39,9 +39,11 @@ Several tools are available by default:
 
 - **bash** &ndash; executes shell commands via `Runtime.bash`.
 - **write_file** &ndash; writes files through `Runtime.write_file`.
-- **delegate_task** &ndash; start a background task handled by a new agent.
+- **delegate_task** &ndash; start a background task handled by a new agent,
+  optionally copying files into it.
 - **task_status** &ndash; check the progress of a delegated task.
 - **collect_file** &ndash; copy a file from a delegated task into the current workspace.
+- **download_file** &ndash; retrieve the contents of a file from the workspace.
 
 Additional tools can be registered programmatically using
 `pygent.register_tool` or the `pygent.tool` decorator. Each tool receives the
@@ -68,15 +70,17 @@ Refer to the `tools.py` module for more details.
 Launch separate agents asynchronously and track them:
 
 ```python
-from pygent import TaskManager
+from pygent import TaskManager, Runtime
 
+rt = Runtime(use_docker=False)
 tm = TaskManager()
-task_id = tm.start_task("generate report")
+task_id = tm.start_task("generate report", rt, files=["data.txt"])
 print(tm.status(task_id))
 ```
-Delegated agents cannot create further tasks. The maximum number of concurrent
-tasks is controlled by the ``PYGENT_MAX_TASKS`` environment variable (default
-``3``).
+Pass a ``Runtime`` instance when starting a task so files can be copied into the
+sub-agent workspace via the optional ``files`` argument. Delegated agents cannot
+create further tasks. The maximum number of concurrent tasks is controlled by
+the ``PYGENT_MAX_TASKS`` environment variable (default ``3``).
 
 ## Custom prompts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_MODEL` | Model name used for requests. | `gpt-4.1-mini` |
 | `PYGENT_IMAGE` | Docker image used for sandboxed execution. | `python:3.12-slim` |
 | `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
+| `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
 
 See [Getting Started](getting-started.md) for installation instructions and the
 [API Reference](api-reference.md) for details about the available classes.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,5 +7,6 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [write_file_demo.py](https://github.com/marianochaves/pygent/blob/main/examples/write_file_demo.py) &ndash; calling the built-in tools from Python code.
 - [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) &ndash; implementing a simple custom model.
 - [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) &ndash; registering a custom tool.
+- [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py) &ndash; delegating work to a background agent.
 
 Run these with `python <script>` from the project root. They expect the environment variables described in the [Configuration](configuration.md) page.

--- a/examples/delegate_task_example.py
+++ b/examples/delegate_task_example.py
@@ -1,0 +1,13 @@
+"""Demonstrate delegating a task to a sub-agent."""
+import time
+from pygent import TaskManager, Runtime
+
+manager = TaskManager()
+tid = manager.start_task("write_file path='hello.txt' content='hi'\nstop")
+print("Started", tid)
+while manager.status(tid) == "running":
+    time.sleep(1)
+print("Status:", manager.status(tid))
+rt = Runtime(use_docker=False)
+print(manager.collect_file(rt, tid, "hello.txt"))
+rt.cleanup()

--- a/examples/delegate_task_example.py
+++ b/examples/delegate_task_example.py
@@ -3,11 +3,16 @@ import time
 from pygent import TaskManager, Runtime
 
 manager = TaskManager()
-tid = manager.start_task("write_file path='hello.txt' content='hi'\nstop")
+main_rt = Runtime(use_docker=False)
+main_rt.write_file("msg.txt", "hi")
+tid = manager.start_task(
+    "bash cmd='cat msg.txt'\nwrite_file path='hello.txt' content='done'\nstop",
+    main_rt,
+    files=["msg.txt"],
+)
 print("Started", tid)
 while manager.status(tid) == "running":
     time.sleep(1)
 print("Status:", manager.status(tid))
-rt = Runtime(use_docker=False)
-print(manager.collect_file(rt, tid, "hello.txt"))
-rt.cleanup()
+print(manager.collect_file(main_rt, tid, "hello.txt"))
+main_rt.cleanup()

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -10,6 +10,7 @@ from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __
 from .models import Model, OpenAIModel  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool  # noqa: E402,F401
+from .task_manager import TaskManager  # noqa: E402,F401
 
 __all__ = [
     "Agent",
@@ -20,4 +21,5 @@ __all__ = [
     "APIError",
     "register_tool",
     "tool",
+    "TaskManager",
 ]

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -20,10 +20,10 @@ DEFAULT_MODEL = os.getenv("PYGENT_MODEL", "gpt-4.1-mini")
 SYSTEM_MSG = (
     "You are Pygent, a sandboxed coding assistant.\n"
     "Respond with JSON when you need to use a tool."
-    "If you need to stop, call the `stop` tool.\n"
+    "If you need to stop or finished you task, call the `stop` tool.\n"
     "You can use the following tools:\n"
     f"{json.dumps(tools.TOOL_SCHEMAS, indent=2)}\n"
-    "You can also use the `continue` tool to continue the conversation.\n"
+    "You can also use the `continue` tool to request user input or continue the conversation.\n"
 )
 
 console = Console()

--- a/pygent/runtime.py
+++ b/pygent/runtime.py
@@ -92,6 +92,24 @@ class Runtime:
         p.write_text(content, encoding="utf-8")
         return f"Wrote {p.relative_to(self.base_dir)}"
 
+    def read_file(self, path: Union[str, Path], binary: bool = False) -> str:
+        """Return the contents of a file relative to the workspace."""
+
+        p = self.base_dir / path
+        if not p.exists():
+            return f"file {p.relative_to(self.base_dir)} not found"
+        data = p.read_bytes()
+        if binary:
+            import base64
+
+            return base64.b64encode(data).decode()
+        try:
+            return data.decode()
+        except UnicodeDecodeError:
+            import base64
+
+            return base64.b64encode(data).decode()
+
     def cleanup(self) -> None:
         if self._use_docker and self.container is not None:
             try:

--- a/pygent/task_manager.py
+++ b/pygent/task_manager.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Manage background tasks executed by sub-agents."""
+
+import os
+import shutil
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Callable, Dict, TYPE_CHECKING
+
+from .runtime import Runtime
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .agent import Agent
+
+
+@dataclass
+class Task:
+    """Represents a delegated task."""
+
+    id: str
+    agent: "Agent"
+    thread: threading.Thread
+    status: str = field(default="running")
+
+
+class TaskManager:
+    """Launch agents asynchronously and track their progress."""
+
+    def __init__(
+        self,
+        agent_factory: Callable[[], "Agent"] | None = None,
+        max_tasks: int | None = None,
+    ) -> None:
+        from .agent import Agent  # local import to avoid circular dependency
+
+        env_max = os.getenv("PYGENT_MAX_TASKS")
+        self.max_tasks = max_tasks if max_tasks is not None else int(env_max or "3")
+        self.agent_factory = agent_factory or Agent
+        self.tasks: Dict[str, Task] = {}
+        self._lock = threading.Lock()
+
+    def start_task(self, prompt: str, parent_depth: int = 0) -> str:
+        """Create a new agent and run ``prompt`` asynchronously."""
+
+        if parent_depth >= 1:
+            raise RuntimeError("nested delegation is not allowed")
+
+        with self._lock:
+            active = sum(t.status == "running" for t in self.tasks.values())
+            if active >= self.max_tasks:
+                raise RuntimeError(f"max {self.max_tasks} tasks reached")
+
+        agent = self.agent_factory()
+        setattr(agent.runtime, "task_depth", parent_depth + 1)
+        task_id = uuid.uuid4().hex[:8]
+        task = Task(id=task_id, agent=agent, thread=None)  # type: ignore[arg-type]
+
+        def run() -> None:
+            try:
+                agent.run_until_stop(prompt)
+                task.status = "finished"
+            except Exception as exc:  # pragma: no cover - error propagation
+                task.status = f"error: {exc}"
+
+        t = threading.Thread(target=run, daemon=True)
+        task.thread = t
+        with self._lock:
+            self.tasks[task_id] = task
+        t.start()
+        return task_id
+
+    def status(self, task_id: str) -> str:
+        with self._lock:
+            task = self.tasks.get(task_id)
+        if not task:
+            return f"Task {task_id} not found"
+        return task.status
+
+    def collect_file(self, rt: Runtime, task_id: str, path: str) -> str:
+        """Copy a file from a task workspace into ``rt``."""
+
+        with self._lock:
+            task = self.tasks.get(task_id)
+        if not task:
+            return f"Task {task_id} not found"
+        src = task.agent.runtime.base_dir / path
+        if not src.exists():
+            return f"file {path} not found"
+        dest = rt.base_dir / path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(src, dest)
+        return f"Retrieved {dest.relative_to(rt.base_dir)}"

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -92,7 +92,7 @@ def _write_file(rt: Runtime, path: str, content: str) -> str:
 
 @tool(
     name="stop",
-    description="Stop the autonomous loop.",
+    description="Stop the autonomous loop. This is a side-effect free tool that does not return any output. Use when finished some task or when you want to stop the agent.",
     parameters={"type": "object", "properties": {}},
 )
 def _stop(rt: Runtime) -> str:  # pragma: no cover - side-effect free
@@ -101,7 +101,7 @@ def _stop(rt: Runtime) -> str:  # pragma: no cover - side-effect free
 
 @tool(
     name="continue",
-    description="Continue the conversation.",
+    description="Request user answer or input. If in your previous message you asked for user input, you can use this tool to continue the conversation.",
     parameters={"type": "object", "properties": {}},
 )
 def _continue(rt: Runtime) -> str:  # pragma: no cover - side-effect free

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "pygent"
-version = "0.1.12"
+version = "0.1.13"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
+readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,152 @@
+import os
+import sys
+import types
+import time
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# mocks for rich
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent
+from pygent import openai_compat
+from pygent.task_manager import TaskManager
+from pygent.runtime import Runtime
+from pygent import tools
+
+class DummyModel:
+    def __init__(self):
+        self.count = 0
+    def chat(self, messages, model, tool_schemas):
+        self.count += 1
+        if self.count == 1:
+            return openai_compat.Message(
+                role='assistant',
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id='1',
+                        type='function',
+                        function=openai_compat.ToolCallFunction(
+                            name='write_file',
+                            arguments='{"path": "foo.txt", "content": "bar"}'
+                        )
+                    )
+                ]
+            )
+        else:
+            return openai_compat.Message(
+                role='assistant',
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id='2',
+                        type='function',
+                        function=openai_compat.ToolCallFunction(
+                            name='stop',
+                            arguments='{}'
+                        )
+                    )
+                ]
+            )
+
+def make_agent():
+    return Agent(runtime=Runtime(use_docker=False), model=DummyModel())
+
+def test_delegate_and_collect_file(tmp_path):
+    tm = TaskManager(agent_factory=make_agent)
+    tools._task_manager = tm
+
+    task_id = tools._delegate_task(Runtime(use_docker=False), prompt='run')
+    tid = task_id.split()[-1]
+    tm.tasks[tid].thread.join()
+
+    status = tools._task_status(Runtime(use_docker=False), task_id=tid)
+    assert status == 'finished'
+
+    main_rt = Runtime(use_docker=False)
+    msg = tools._collect_file(main_rt, task_id=tid, path='foo.txt')
+    assert 'Retrieved' in msg
+    copied = main_rt.base_dir / 'foo.txt'
+    assert copied.exists() and copied.read_text() == 'bar'
+    main_rt.cleanup()
+
+
+class DelegateModel:
+    def __init__(self):
+        self.count = 0
+    def chat(self, messages, model, tool_schemas):
+        self.count += 1
+        if self.count == 1:
+            return openai_compat.Message(
+                role='assistant',
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id='1',
+                        type='function',
+                        function=openai_compat.ToolCallFunction(
+                            name='delegate_task',
+                            arguments='{"prompt": "noop"}'
+                        )
+                    )
+                ]
+            )
+        else:
+            return openai_compat.Message(
+                role='assistant',
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id='2',
+                        type='function',
+                        function=openai_compat.ToolCallFunction(
+                            name='stop',
+                            arguments='{}'
+                        )
+                    )
+                ]
+            )
+
+
+def make_delegate_agent():
+    return Agent(runtime=Runtime(use_docker=False), model=DelegateModel())
+
+
+def test_no_nested_delegation():
+    tm = TaskManager(agent_factory=make_delegate_agent, max_tasks=2)
+    tools._task_manager = tm
+
+    tid_msg = tools._delegate_task(Runtime(use_docker=False), prompt='run')
+    tid = tid_msg.split()[-1]
+    tm.tasks[tid].thread.join()
+
+    # No new tasks should have been created inside the sub-agent
+    assert len(tm.tasks) == 1
+
+
+def test_task_limit():
+    tm = TaskManager(agent_factory=make_agent, max_tasks=1)
+    tools._task_manager = tm
+
+    first = tools._delegate_task(Runtime(use_docker=False), prompt='run')
+    assert first.startswith('started')
+
+    second = tools._delegate_task(Runtime(use_docker=False), prompt='run')
+    assert 'max' in second


### PR DESCRIPTION
## Summary
- implement TaskManager for asynchronous task delegation
- expose TaskManager in package API
- add tools delegate_task, task_status, and collect_file
- document new tools and TaskManager
- enforce delegation limits and max concurrent tasks
- add delegate_task example and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609a29067c8321b3f4ae6813586c9d