### PR TITLE
Add timeouts for steps and delegated tasks

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,8 +13,8 @@ Manages the conversation with the model. Each instance owns a
 
 **Methods**
 
-- `step(user_msg: str) -> None` – add a message, run tools and print
-  their output.
+- `step(user_msg: str) -> None` – add a message and run any tools
+  returned by the model.
 - `run_interactive(use_docker: bool | None = None) -> None` – start an
   interactive session.
 - `run_gui(use_docker: bool | None = None) -> None` – start a simple
@@ -74,13 +74,22 @@ from pygent import TaskManager, Runtime
 
 rt = Runtime(use_docker=False)
 tm = TaskManager()
-task_id = tm.start_task("generate report", rt, files=["data.txt"])
+task_id = tm.start_task(
+    "generate report",
+    rt,
+    files=["data.txt"],
+    step_timeout=5,
+    task_timeout=60,
+)
 print(tm.status(task_id))
 ```
 Pass a ``Runtime`` instance when starting a task so files can be copied into the
 sub-agent workspace via the optional ``files`` argument. Delegated agents cannot
 create further tasks. The maximum number of concurrent tasks is controlled by
 the ``PYGENT_MAX_TASKS`` environment variable (default ``3``).
+Optional ``step_timeout`` and ``task_timeout`` parameters control how long each
+step and the overall task are allowed to run. Their defaults can be set via the
+``PYGENT_STEP_TIMEOUT`` and ``PYGENT_TASK_TIMEOUT`` environment variables.
 
 ## Custom prompts
 
@@ -97,3 +106,4 @@ The `Agent` relies on a model object with a ``chat`` method. The default is
 ``OpenAIModel`` which calls an OpenAI-compatible API. To plug in a different
 backend, implement the ``Model`` protocol and pass an instance when creating the
 agent.
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,8 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_IMAGE` | Docker image used for sandboxed execution. | `python:3.12-slim` |
 | `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
 | `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
+| `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |
+| `PYGENT_TASK_TIMEOUT` | Default overall time limit in seconds for delegated tasks. | – |
 
 See [Getting Started](getting-started.md) for installation instructions and the
 [API Reference](api-reference.md) for details about the available classes.

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -44,7 +44,10 @@ class Agent:
             self.history.append({"role": "system", "content": self.system_msg})
 
     def step(self, user_msg: str):
+        """Execute one round of interaction with the model."""
+
         self.history.append({"role": "user", "content": user_msg})
+
         assistant_msg = self.model.chat(
             self.history, self.model_name, tools.TOOL_SCHEMAS
         )
@@ -60,12 +63,36 @@ class Agent:
             console.print(Panel(markdown_response, title="Resposta do Agente", title_align="left", border_style="cyan"))
         return assistant_msg
 
-    def run_until_stop(self, user_msg: str, max_steps: int = 10) -> None:
-        """Run steps automatically until the model calls the ``stop`` tool or
-        the step limit is reached."""
+    def run_until_stop(
+        self,
+        user_msg: str,
+        max_steps: int = 10,
+        step_timeout: float | None = None,
+        max_time: float | None = None,
+    ) -> None:
+        """Run steps until ``stop`` is called or limits are reached."""
+
+        if step_timeout is None:
+            env = os.getenv("PYGENT_STEP_TIMEOUT")
+            step_timeout = float(env) if env else None
+        if max_time is None:
+            env = os.getenv("PYGENT_TASK_TIMEOUT")
+            max_time = float(env) if env else None
+
         msg = user_msg
+        start = time.monotonic()
+        self._timed_out = False
         for _ in range(max_steps):
+            if max_time is not None and time.monotonic() - start > max_time:
+                self.history.append({"role": "system", "content": f"[timeout after {max_time}s]"})
+                self._timed_out = True
+                break
+            step_start = time.monotonic()
             assistant_msg = self.step(msg)
+            if step_timeout is not None and time.monotonic() - step_start > step_timeout:
+                self.history.append({"role": "system", "content": f"[timeout after {step_timeout}s]"})
+                self._timed_out = True
+                break
             calls = assistant_msg.tool_calls or []
             if any(c.function.name in ("stop", "continue") for c in calls):
                 break

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -66,7 +66,7 @@ class Agent:
     def run_until_stop(
         self,
         user_msg: str,
-        max_steps: int = 10,
+        max_steps: int = 20,
         step_timeout: float | None = None,
         max_time: float | None = None,
     ) -> None:

--- a/pygent/task_manager.py
+++ b/pygent/task_manager.py
@@ -62,10 +62,10 @@ class TaskManager:
 
         if step_timeout is None:
             env = os.getenv("PYGENT_STEP_TIMEOUT")
-            step_timeout = float(env) if env else None
+            step_timeout = float(env) if env else 60*5 # default 5 minutes
         if task_timeout is None:
             env = os.getenv("PYGENT_TASK_TIMEOUT")
-            task_timeout = float(env) if env else None
+            task_timeout = float(env) if env else 60*20 # default 20 minutes
 
         agent = self.agent_factory()
         setattr(agent.runtime, "task_depth", parent_depth + 1)

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -122,11 +122,19 @@ def _continue(rt: Runtime) -> str:  # pragma: no cover - side-effect free
                 "items": {"type": "string"},
                 "description": "Files to copy to the sub-agent before starting",
             },
+            "timeout": {"type": "number", "description": "Max seconds for the task"},
+            "step_timeout": {"type": "number", "description": "Time limit per step"},
         },
         "required": ["prompt"],
     },
 )
-def _delegate_task(rt: Runtime, prompt: str, files: list[str] | None = None) -> str:
+def _delegate_task(
+    rt: Runtime,
+    prompt: str,
+    files: list[str] | None = None,
+    timeout: float | None = None,
+    step_timeout: float | None = None,
+) -> str:
     if getattr(rt, "task_depth", 0) >= 1:
         return "error: delegation not allowed in sub-tasks"
     try:
@@ -135,6 +143,8 @@ def _delegate_task(rt: Runtime, prompt: str, files: list[str] | None = None) -> 
             parent_rt=rt,
             files=files,
             parent_depth=getattr(rt, "task_depth", 0),
+            step_timeout=step_timeout,
+            task_timeout=timeout,
         )
     except RuntimeError as exc:
         return str(exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.13"
+version = "0.1.14"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -185,3 +185,19 @@ def test_task_limit():
     assert 'max' in second
 
     tm.tasks[tid].thread.join()
+
+
+def test_step_timeout():
+    ag = make_slow_agent()
+    ag.run_until_stop('run', step_timeout=0.05, max_steps=1)
+    assert 'timeout' in ag.history[-1]["content"]
+
+
+def test_task_timeout():
+    tm = TaskManager(agent_factory=make_slow_agent, max_tasks=1)
+    tools._task_manager = tm
+    rt = Runtime(use_docker=False)
+    tid = tm.start_task('run', rt, task_timeout=0.05, step_timeout=0.01)
+    tm.tasks[tid].thread.join()
+    assert 'timeout' in tm.status(tid)
+


### PR DESCRIPTION
## Summary
- allow specifying a timeout when running `Agent.run_until_stop` and delegated tasks
- use `PYGENT_STEP_TIMEOUT` and `PYGENT_TASK_TIMEOUT` env vars as defaults
- update docs for new timeout behaviour and env variables
- adjust tests for step timeout semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a96de1b8832194e84d99c0756df2