### PR TITLE
Add config path CLI option and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ pygent
 Use `--docker` to run commands inside a container (requires
 `pygent[docker]`). Use `--no-docker` or set `PYGENT_USE_DOCKER=0`
 to force local execution.
+Pass `--config path/to/pygent.toml` to load settings from a file.
 
 Type messages normally; use `/exit` to end the session. Each command is executed
 in the container and the result shown in the terminal.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,28 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
 | `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |
 | `PYGENT_TASK_TIMEOUT` | Default overall time limit in seconds for delegated tasks. | – |
+| `PYGENT_PERSONA` | System prompt preamble for the main agent. | "You are Pygent, a sandboxed coding assistant." |
+| `PYGENT_TASK_PERSONAS` | List of personas for delegated agents separated by `os.pathsep`. | – |
+| `PYGENT_INIT_FILES` | List of files or directories copied into the workspace at startup, separated by `os.pathsep`. | – |
+
+Instead of setting environment variables you can create a `pygent.toml` file in
+the current directory or in your home folder. Values defined there are loaded at
+startup if the corresponding variables are unset. Example:
+
+```toml
+persona = "You are a friendly bot"
+task_personas = ["tester", "developer"]
+initial_files = ["bootstrap.py"]
+```
+
+The keys map to the environment variables of the same name.
+
+You can also specify a configuration file explicitly when launching the CLI:
+
+```bash
+pygent --config path/to/pygent.toml
+```
+
 
 See [Getting Started](getting-started.md) for installation instructions and the
 [API Reference](api-reference.md) for details about the available classes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Python ≥ 3.9 is required. Docker is optional; install `pygent[docker]` to enab
 ## Basic usage
 
 Start an interactive session by running `pygent` in the terminal. Use the `--docker` option to run commands in a container (requires `pygent[docker]`); otherwise they execute locally. Use `/exit` to quit.
+Pass `--config path/to/pygent.toml` to load settings from a file.
 Alternatively run `pygent-ui` for a simple web interface (requires `pygent[ui]`).
 
 You can also use the Python API:

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -1,6 +1,8 @@
 """Pygent package."""
 from importlib import metadata as _metadata
 
+from .config import load_config
+
 try:
     __version__: str = _metadata.version(__name__)
 except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
@@ -15,6 +17,7 @@ from .task_manager import TaskManager  # noqa: E402,F401
 __all__ = [
     "Agent",
     "run_interactive",
+    "load_config",
     "Model",
     "OpenAIModel",
     "PygentError",

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -1,12 +1,16 @@
 """Command-line entry point for Pygent."""
 import argparse
 
-from .agent import run_interactive
+from .config import load_config
 
 def main() -> None:  # pragma: no cover
     parser = argparse.ArgumentParser(prog="pygent")
     parser.add_argument("--docker", dest="use_docker", action="store_true", help="run commands in a Docker container")
     parser.add_argument("--no-docker", dest="use_docker", action="store_false", help="run locally")
+    parser.add_argument("-c", "--config", help="path to configuration file")
     parser.set_defaults(use_docker=None)
     args = parser.parse_args()
+    load_config(args.config)
+    from .agent import run_interactive
+
     run_interactive(use_docker=args.use_docker)

--- a/pygent/config.py
+++ b/pygent/config.py
@@ -1,0 +1,40 @@
+import os
+import tomllib
+from pathlib import Path
+from typing import Any, Dict
+
+DEFAULT_CONFIG_FILES = [
+    Path("pygent.toml"),
+    Path.home() / ".pygent.toml",
+]
+
+def load_config(path: str | os.PathLike[str] | None = None) -> Dict[str, Any]:
+    """Load configuration from a TOML file and set environment variables.
+
+    Environment variables already set take precedence over file values.
+    Returns the configuration dictionary.
+    """
+    config: Dict[str, Any] = {}
+    paths = [Path(path)] if path else DEFAULT_CONFIG_FILES
+    for p in paths:
+        if p.is_file():
+            with p.open("rb") as fh:
+                try:
+                    data = tomllib.load(fh)
+                except Exception:
+                    continue
+            config.update(data)
+    # update environment without overwriting existing values
+    if "persona" in config and "PYGENT_PERSONA" not in os.environ:
+        os.environ["PYGENT_PERSONA"] = str(config["persona"])
+    if "task_personas" in config and "PYGENT_TASK_PERSONAS" not in os.environ:
+        if isinstance(config["task_personas"], list):
+            os.environ["PYGENT_TASK_PERSONAS"] = os.pathsep.join(str(p) for p in config["task_personas"])
+        else:
+            os.environ["PYGENT_TASK_PERSONAS"] = str(config["task_personas"])
+    if "initial_files" in config and "PYGENT_INIT_FILES" not in os.environ:
+        if isinstance(config["initial_files"], list):
+            os.environ["PYGENT_INIT_FILES"] = os.pathsep.join(str(p) for p in config["initial_files"])
+        else:
+            os.environ["PYGENT_INIT_FILES"] = str(config["initial_files"])
+    return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.14"
+version = "0.1.15"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# minimal mocks for rich
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent.config import load_config
+from pygent.runtime import Runtime
+from pygent.task_manager import TaskManager
+
+
+def test_load_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "pygent.toml"
+    cfg.write_text('persona="bot"\ntask_personas=["a","b"]\ninitial_files=["seed.txt"]')
+    (tmp_path / "seed.txt").write_text("seed")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PYGENT_PERSONA", raising=False)
+    monkeypatch.delenv("PYGENT_TASK_PERSONAS", raising=False)
+    monkeypatch.delenv("PYGENT_INIT_FILES", raising=False)
+    load_config()
+    assert os.getenv("PYGENT_PERSONA") == "bot"
+    assert os.getenv("PYGENT_TASK_PERSONAS") == os.pathsep.join(["a", "b"])
+    assert os.getenv("PYGENT_INIT_FILES") == "seed.txt"
+    rt = Runtime(use_docker=False)
+    assert (rt.base_dir / "seed.txt").exists()
+    rt.cleanup()
+
+
+def test_task_manager_personas(monkeypatch):
+    created = []
+    def factory(p):
+        created.append(p)
+        ag = types.SimpleNamespace(runtime=Runtime(use_docker=False), model=None, persona=p)
+        ag.run_until_stop = lambda *a, **k: None
+        return ag
+    tm = TaskManager(agent_factory=factory, personas=["one","two"])
+    tm.start_task("noop", Runtime(use_docker=False))
+    tm.start_task("noop", Runtime(use_docker=False))
+    tm.tasks[next(iter(tm.tasks))].thread.join()
+    assert created == ["one","two"]


### PR DESCRIPTION
## Summary
- allow `pygent` CLI to load configuration file via `--config`
- remove automatic config loading from package init
- document explicit config file usage
- bump version to 0.1.15

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b89fece483219f1776ded37a76c3