### PR TITLE
Add configuration file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Behaviour can be adjusted via environment variables (see `docs/configuration.md`
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
 * `PYGENT_MAX_TASKS` &ndash; maximum number of concurrent delegated tasks (default `3`).
 
+Settings can also be read from a `pygent.toml` file. See
+[examples/sample_config.toml](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)
+and the accompanying
+[config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py)
+script for a working demonstration that generates tests using a delegated agent.
+
 ## CLI usage
 
 After installing run:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,15 @@ You can also specify a configuration file explicitly when launching the CLI:
 pygent --config path/to/pygent.toml
 ```
 
+A practical example is included in
+[`examples/sample_config.toml`](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)
+together with the script
+[`config_file_example.py`](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py), which delegates a testing task:
+
+```bash
+python examples/config_file_example.py
+```
+
 
 See [Getting Started](getting-started.md) for installation instructions and the
 [API Reference](api-reference.md) for details about the available classes.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,5 +8,6 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) &ndash; implementing a simple custom model.
 - [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) &ndash; registering a custom tool.
 - [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py) &ndash; delegating work to a background agent.
+- [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) &ndash; loading a config file and delegating a testing agent.
 
 Run these with `python <script>` from the project root. They expect the environment variables described in the [Configuration](configuration.md) page.

--- a/examples/config_file_example.py
+++ b/examples/config_file_example.py
@@ -1,0 +1,27 @@
+"""Use a config file and delegate unit test generation."""
+from pathlib import Path
+import time
+from pygent import Agent, load_config, TaskManager
+
+base = Path(__file__).resolve().parent
+load_config(base / "sample_config.toml")
+
+main = Agent()
+manager = TaskManager()
+
+# Create a small Python module
+main.step("write_file path='calc.py' content='def add(a, b): return a + b'")
+
+# Launch a sub-agent that writes tests for the module
+task_id = manager.start_task(
+    "Write pytest tests for calc.py in test_calc.py and stop", main.runtime, files=["calc.py"]
+)
+print("Started", task_id)
+
+while manager.status(task_id) == "running":
+    time.sleep(1)
+
+print("Status:", manager.status(task_id))
+print(manager.collect_file(main.runtime, task_id, "test_calc.py"))
+
+main.runtime.cleanup()

--- a/examples/sample_config.toml
+++ b/examples/sample_config.toml
@@ -1,0 +1,4 @@
+# Sample configuration for config_file_example.py
+persona = "You are the config bot"
+task_personas = ["You are the test bot"]
+initial_files = ["examples/welcome.txt"]

--- a/examples/welcome.txt
+++ b/examples/welcome.txt
@@ -1,0 +1,1 @@
+Hello from the config file!


### PR DESCRIPTION
## Summary
- expand `config_file_example.py` to launch a delegated testing agent
- update `sample_config.toml` with a persona for delegated agents
- mention the new delegated testing example in docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861a9457ab08321813834ca36aaf999