### PR TITLE
Document custom models with tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ ag.runtime.cleanup()
 See the [examples](https://github.com/marianochaves/pygent/tree/main/examples) folder for more complete scripts. Models can be swapped by
 passing an object implementing the ``Model`` interface when creating the
 ``Agent``. The default uses an OpenAI-compatible API, but custom models are
-easy to plug in.
+easy to plug in. They can also trigger tools by returning a message with
+``tool_calls`` as demonstrated in ``examples/custom_model_with_tool.py``.
 
 ### Using OpenAI and other providers
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -118,5 +118,6 @@ ag = Agent(persona=Persona("Helper", "a friendly bot"))
 The `Agent` relies on a model object with a ``chat`` method. The default is
 ``OpenAIModel`` which calls an OpenAI-compatible API. To plug in a different
 backend, implement the ``Model`` protocol and pass an instance when creating the
-agent.
+agent. Custom models may return tool calls by populating the ``tool_calls``
+attribute of the returned message.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,6 +6,7 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [runtime_example.py](https://github.com/marianochaves/pygent/blob/main/examples/runtime_example.py) &ndash; using the :class:`~pygent.runtime.Runtime` class directly.
 - [write_file_demo.py](https://github.com/marianochaves/pygent/blob/main/examples/write_file_demo.py) &ndash; calling the built-in tools from Python code.
 - [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) &ndash; implementing a simple custom model.
+- [custom_model_with_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model_with_tool.py) &ndash; custom model issuing tool calls.
 - [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) &ndash; registering a custom tool.
 - [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py) &ndash; delegating work to a background agent.
 - [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) &ndash; loading a config file and delegating a testing agent.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,5 +94,32 @@ ag.step("test")
 ag.runtime.cleanup()
 ```
 
+Custom models can also issue tool calls. The following model runs the last user
+message as a `bash` command:
+
+```python
+import json
+from pygent import Agent, openai_compat
+
+
+class BashModel:
+    def chat(self, messages, model, tools):
+        cmd = messages[-1]["content"]
+        call = openai_compat.ToolCall(
+            id="1",
+            type="function",
+            function=openai_compat.ToolCallFunction(
+                name="bash",
+                arguments=json.dumps({"cmd": cmd}),
+            ),
+        )
+        return openai_compat.Message(role="assistant", content=None, tool_calls=[call])
+
+
+ag = Agent(model=BashModel())
+ag.step("echo hi")
+ag.runtime.cleanup()
+```
+
 See the [API reference](api-reference.md) for the complete list of classes and
 configuration options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,8 @@ ag.runtime.cleanup()
 ```
 
 Custom models are supported by implementing the ``Model`` protocol and passing
-the instance to ``Agent``.
+the instance to ``Agent``. They can also trigger tools by returning a message
+with ``tool_calls`` as shown in the ``custom_model_with_tool.py`` example.
 
 ## Development
 

--- a/examples/custom_model_with_tool.py
+++ b/examples/custom_model_with_tool.py
@@ -1,0 +1,24 @@
+"""Custom model returning a tool call."""
+import json
+from pygent import Agent, openai_compat
+
+
+class BashModel:
+    """Return a bash tool call for the last user message."""
+
+    def chat(self, messages, model, tools):
+        cmd = messages[-1]["content"]
+        call = openai_compat.ToolCall(
+            id="1",
+            type="function",
+            function=openai_compat.ToolCallFunction(
+                name="bash",
+                arguments=json.dumps({"cmd": cmd}),
+            ),
+        )
+        return openai_compat.Message(role="assistant", content=None, tool_calls=[call])
+
+
+ag = Agent(model=BashModel())
+ag.step("echo 'hi from tool'")
+ag.runtime.cleanup()

--- a/tests/test_custom_model_tool.py
+++ b/tests/test_custom_model_tool.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent, openai_compat
+
+
+class BashModel:
+    def chat(self, messages, model, tools):
+        call = openai_compat.ToolCall(
+            id='1',
+            type='function',
+            function=openai_compat.ToolCallFunction(
+                name='bash',
+                arguments='{"cmd": "echo hi"}'
+            )
+        )
+        return openai_compat.Message(role='assistant', content=None, tool_calls=[call])
+
+
+class DummyRuntime:
+    def bash(self, cmd: str):
+        return f'ran {cmd}'
+
+    def write_file(self, path: str, content: str):
+        return f'wrote {path}'
+
+
+def test_custom_model_tool():
+    ag = Agent(runtime=DummyRuntime(), model=BashModel())
+    ag.step('run')
+    assert any(isinstance(m, dict) and m.get('role') == 'tool' for m in ag.history)


### PR DESCRIPTION
## Summary
- add `custom_model_with_tool.py` example
- document how custom models can return tool calls
- mention new example across docs and README
- test custom model returning a tool call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f215a4ec8321b64b400e15c45626