### PR TITLE
Handle tomllib on Python <3.11

### DIFF
--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -1,12 +1,25 @@
 """Pygent package."""
 from importlib import metadata as _metadata
+from pathlib import Path
 
 from .config import load_config
 
 try:
     __version__: str = _metadata.version(__name__)
 except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
-    __version__ = "0.0.0"
+    try:  # Python 3.11+
+        import tomllib  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - executed on older Python versions
+        import tomli as tomllib  # type: ignore
+
+    _root = Path(__file__).resolve().parent.parent
+    pyproject = _root / "pyproject.toml"
+    if pyproject.is_file():
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+        __version__ = data.get("project", {}).get("version", "0.0.0")
+    else:
+        __version__ = "0.0.0"
 
 from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __version__
 from .models import Model, OpenAIModel  # noqa: E402,F401

--- a/pygent/config.py
+++ b/pygent/config.py
@@ -1,6 +1,9 @@
 import os
 import json
-import tomllib
+try:  # Python 3.11+
+    import tomllib  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed on older Python versions
+    import tomli as tomllib  # type: ignore
 from pathlib import Path
 from typing import Any, Dict, List, Mapping
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.16"
+version = "0.1.18"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]
@@ -8,6 +8,7 @@ requires-python = ">=3.9"
 dependencies = [
     "rich>=13.7.0",
     "openai>=1.0.0",
+    "tomli; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add fallback to `tomli` if `tomllib` is unavailable
- declare `tomli` as conditional dependency for Python <3.11
- read version from pyproject when package metadata missing
- bump version to 0.1.18

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862be1d54a0832181bae3a51ae182c5