### PR TITLE
Add global custom model variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ passing an object implementing the ``Model`` interface when creating the
 easy to plug in. They can also trigger tools by returning a message with
 ``tool_calls`` as demonstrated in ``examples/custom_model_with_tool.py``.
 
+Custom models can also be configured globally:
+
+```python
+from pygent.models import set_custom_model
+set_custom_model(MyModel())
+```
+
+All new agents and delegated tasks will use this model unless another one is passed explicitly.
+
 ### Using OpenAI and other providers
 
 Set your OpenAI key:

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -22,7 +22,7 @@ except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
         __version__ = "0.0.0"
 
 from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __version__
-from .models import Model, OpenAIModel  # noqa: E402,F401
+from .models import Model, OpenAIModel, set_custom_model  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool  # noqa: E402,F401
 from .task_manager import TaskManager  # noqa: E402,F401
@@ -33,6 +33,7 @@ __all__ = [
     "load_config",
     "Model",
     "OpenAIModel",
+    "set_custom_model",
     "PygentError",
     "APIError",
     "register_tool",

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -13,7 +13,7 @@ from rich.panel import Panel
 from rich.markdown import Markdown
 
 from .runtime import Runtime
-from . import tools
+from . import tools, models
 from .models import Model, OpenAIModel
 from .persona import Persona
 
@@ -38,12 +38,18 @@ SYSTEM_MSG = build_system_msg(DEFAULT_PERSONA)
 console = Console()
 
 
+def _default_model() -> Model:
+    """Return the global custom model or the default OpenAI model."""
+    return models.CUSTOM_MODEL or OpenAIModel()
+
+
+
 
 
 @dataclass
 class Agent:
     runtime: Runtime = field(default_factory=Runtime)
-    model: Model = field(default_factory=OpenAIModel)
+    model: Model = field(default_factory=_default_model)
     model_name: str = DEFAULT_MODEL
     persona: Persona = field(default_factory=lambda: DEFAULT_PERSONA)
     system_msg: str = field(default_factory=lambda: build_system_msg(DEFAULT_PERSONA))

--- a/pygent/models.py
+++ b/pygent/models.py
@@ -35,3 +35,14 @@ class OpenAIModel:
             return resp.choices[0].message
         except Exception as exc:
             raise APIError(str(exc)) from exc
+
+
+# global custom model used for all new agents when set
+CUSTOM_MODEL: Model | None = None
+
+
+def set_custom_model(model: Model | None) -> None:
+    """Set a global custom model used by :class:`~pygent.agent.Agent`."""
+
+    global CUSTOM_MODEL
+    CUSTOM_MODEL = model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.18"
+version = "0.1.19"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -38,3 +38,17 @@ def test_custom_model():
     ag.step('hi')
     assert ag.history[-1].content == 'ok'
 
+
+def test_global_custom_model():
+    class GlobalModel:
+        def chat(self, messages, model, tools):
+            return openai_compat.Message(role='assistant', content='global')
+
+    from pygent.models import set_custom_model
+
+    set_custom_model(GlobalModel())
+    ag = Agent()
+    ag.step('ping')
+    set_custom_model(None)
+    assert ag.history[-1].content == 'global'
+

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -247,3 +247,15 @@ def test_personas_from_env(monkeypatch):
     )
     tm = TaskManager()
     assert tm.personas[0].name == "env" and tm.personas[0].description == "desc"
+
+
+def test_global_model_for_tasks():
+    from pygent.models import set_custom_model
+
+    set_custom_model(DummyModel())
+    tm = TaskManager()
+    rt = Runtime(use_docker=False)
+    tid = tm.start_task("run", rt)
+    tm.tasks[tid].thread.join()
+    set_custom_model(None)
+    assert isinstance(tm.tasks[tid].agent.model, DummyModel)


### PR DESCRIPTION
## Summary
- add `set_custom_model` and `CUSTOM_MODEL` to configure a global model
- make `Agent` default to the global model when present
- export the helper via `pygent.__init__`
- document global model usage
- test global model behaviour in agents and tasks
- bump package version to 0.1.19

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686310c7b1688321bdebd078058f497f