### PR TITLE
Handle dict messages from custom models

### DIFF
--- a/pygent/openai_compat.py
+++ b/pygent/openai_compat.py
@@ -9,10 +9,12 @@ from .errors import APIError
 OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
+
 @dataclass
 class ToolCallFunction:
     name: str
     arguments: str
+
 
 @dataclass
 class ToolCall:
@@ -20,15 +22,18 @@ class ToolCall:
     type: str
     function: ToolCallFunction
 
+
 @dataclass
 class Message:
     role: str
     content: str | None = None
     tool_calls: List[ToolCall] | None = None
 
+
 @dataclass
 class Choice:
     message: Message
+
 
 @dataclass
 class ChatCompletion:
@@ -53,7 +58,13 @@ def _post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 class _ChatCompletions:
-    def create(self, model: str, messages: List[Dict[str, Any]], tools: Any = None, tool_choice: str | None = "auto") -> ChatCompletion:
+    def create(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        tools: Any = None,
+        tool_choice: str | None = "auto",
+    ) -> ChatCompletion:
         payload: Dict[str, Any] = {"model": model, "messages": messages}
         if tools is not None:
             payload["tools"] = tools
@@ -66,8 +77,16 @@ class _ChatCompletions:
             tool_calls = []
             for tc in msg_data.get("tool_calls", []):
                 func = ToolCallFunction(**tc.get("function", {}))
-                tool_calls.append(ToolCall(id=tc.get("id", ""), type=tc.get("type", ""), function=func))
-            msg = Message(role=msg_data.get("role", ""), content=msg_data.get("content"), tool_calls=tool_calls or None)
+                tool_calls.append(
+                    ToolCall(
+                        id=tc.get("id", ""), type=tc.get("type", ""), function=func
+                    )
+                )
+            msg = Message(
+                role=msg_data.get("role", ""),
+                content=msg_data.get("content"),
+                tool_calls=tool_calls or None,
+            )
             choices.append(Choice(message=msg))
         return ChatCompletion(choices=choices)
 
@@ -78,3 +97,37 @@ class _Chat:
 
 
 chat = _Chat()
+
+
+def parse_message(raw: Any) -> Message:
+    """Return a :class:`Message` from ``raw`` data.
+
+    Accepts dictionaries and objects from the official OpenAI client.
+    """
+    if isinstance(raw, Message):
+        return raw
+    if isinstance(raw, dict):
+        tool_calls = []
+        for tc in raw.get("tool_calls", []) or []:
+            func_data = tc.get("function", {})
+            func = ToolCallFunction(
+                name=func_data.get("name", ""),
+                arguments=func_data.get("arguments", ""),
+            )
+            tool_calls.append(
+                ToolCall(
+                    id=tc.get("id", ""),
+                    type=tc.get("type", ""),
+                    function=func,
+                )
+            )
+        return Message(
+            role=raw.get("role", ""),
+            content=raw.get("content"),
+            tool_calls=tool_calls or None,
+        )
+    if hasattr(raw, "model_dump"):
+        return parse_message(raw.model_dump())
+    if hasattr(raw, "to_dict"):
+        return parse_message(raw.to_dict())
+    raise TypeError(f"Unsupported message type: {type(raw)!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.19"
+version = "0.1.20"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_dict_model.py
+++ b/tests/test_dict_model.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+sys.modules.setdefault("docker", types.ModuleType("docker"))
+
+rich_mod = types.ModuleType("rich")
+console_mod = types.ModuleType("console")
+panel_mod = types.ModuleType("panel")
+markdown_mod = types.ModuleType("markdown")
+syntax_mod = types.ModuleType("syntax")
+console_mod.Console = lambda *a, **k: type("C", (), {"print": lambda *a, **k: None})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault("rich", rich_mod)
+sys.modules.setdefault("rich.console", console_mod)
+sys.modules.setdefault("rich.panel", panel_mod)
+sys.modules.setdefault("rich.markdown", markdown_mod)
+sys.modules.setdefault("rich.syntax", syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pygent import Agent
+
+
+class DictModel:
+    def chat(self, messages, model, tools):
+        return {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"cmd": "echo hi"}'},
+                }
+            ],
+        }
+
+
+class DummyRuntime:
+    def bash(self, cmd: str):
+        return f"ran {cmd}"
+
+    def write_file(self, path: str, content: str):
+        return f"wrote {path}"
+
+
+def test_dict_model_tool():
+    ag = Agent(runtime=DummyRuntime(), model=DictModel())
+    ag.step("run")
+    assert any(isinstance(m, dict) and m.get("role") == "tool" for m in ag.history)


### PR DESCRIPTION
## Summary
- add `parse_message` utility to handle messages returned as dictionaries
- use `parse_message` in `Agent.step` and UI response
- test dictionary-based custom model
- bump version to 0.1.20

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68631f515acc8321be897f8a00d9b700