### PR TITLE
Add advanced custom model example

### DIFF
--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -1,0 +1,184 @@
+# Custom Models
+
+Pygent allows plugging in any model backend as long as it implements the `Model` protocol. This page collects extended examples showing how to build your own models, use the `openai_compat` helpers and return tool calls.
+
+## Echo model
+
+A trivial example that simply repeats the last user message. The implementation returns an `openai_compat.Message` instance.
+
+```python
+from pygent import Agent, openai_compat
+
+class EchoModel:
+    def chat(self, messages, model, tools):
+        last = messages[-1]["content"]
+        return openai_compat.Message(role="assistant", content=f"Echo: {last}")
+
+ag = Agent(model=EchoModel())
+ag.step("test")
+```
+
+## Calling a remote API with `openai_compat`
+
+The `openai_compat` module ships a lightweight client mirroring the official OpenAI interface. You can use it to talk to any compatible endpoint.
+
+```python
+from pygent import Agent, openai_compat
+
+class HTTPModel:
+    def chat(self, messages, model, tools):
+        resp = openai_compat.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+        )
+        return resp.choices[0].message
+
+ag = Agent(model=HTTPModel())
+ag.step("who am I?")
+```
+
+Set `OPENAI_BASE_URL` and `OPENAI_API_KEY` to target a different provider if needed.
+
+## Returning tool calls
+
+Custom models may trigger tools by returning a message with the `tool_calls` attribute populated. The next example runs the last user message as a `bash` command.
+
+```python
+import json
+from pygent import Agent, openai_compat
+
+class BashModel:
+    def chat(self, messages, model, tools):
+        cmd = messages[-1]["content"]
+        call = openai_compat.ToolCall(
+            id="1",
+            type="function",
+            function=openai_compat.ToolCallFunction(
+                name="bash",
+                arguments=json.dumps({"cmd": cmd}),
+            ),
+        )
+        return openai_compat.Message(role="assistant", content=None, tool_calls=[call])
+
+ag = Agent(model=BashModel())
+ag.step("echo 'hi from tool'")
+```
+
+## Global custom model
+
+Use `set_custom_model` to apply a model to all new agents and delegated tasks:
+
+```python
+from pygent import Agent
+from pygent.models import set_custom_model
+
+set_custom_model(EchoModel())
+ag = Agent()
+ag.step("hello")
+set_custom_model(None)
+```
+
+## Delegating tasks from a custom model
+
+Models can call the `delegate_task` tool to start a background agent. This example delegates once and then stops.
+
+```python
+import json
+from pygent import Agent, openai_compat
+
+class DelegateModel:
+    def __init__(self):
+        self.first = True
+
+    def chat(self, messages, model, tools):
+        if self.first:
+            self.first = False
+            return openai_compat.Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id="1",
+                        type="function",
+                        function=openai_compat.ToolCallFunction(
+                            name="delegate_task",
+                            arguments=json.dumps({"prompt": "noop"}),
+                        ),
+                    )
+                ],
+            )
+        return openai_compat.Message(role="assistant", content=None, tool_calls=[
+            openai_compat.ToolCall(
+                id="2",
+                type="function",
+                function=openai_compat.ToolCallFunction(name="stop", arguments="{}"),
+            )
+        ])
+
+ag = Agent(model=DelegateModel())
+ag.run_until_stop("begin", max_steps=2)
+```
+
+## Custom tool and external model in a delegated task
+
+This scenario combines several features: defining a new tool, using an
+OpenAI-compatible service via ``openai_compat`` and delegating work to a
+background agent.
+
+```python
+import json
+import time
+from pygent import Agent, TaskManager, register_tool, openai_compat
+
+def shout(rt, text: str) -> str:
+    return text.upper()
+
+register_tool(
+    "shout",
+    "Uppercase some text",
+    {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    shout,
+)
+
+class HTTPModel:
+    def chat(self, messages, model, tools):
+        resp = openai_compat.chat.completions.create(
+            model=model, messages=messages, tools=tools, tool_choice="auto"
+        )
+        return resp.choices[0].message
+
+class DelegatingModel:
+    def __init__(self):
+        self.done = False
+
+    def chat(self, messages, model, tools):
+        if not self.done:
+            self.done = True
+            return openai_compat.Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id="1",
+                        type="function",
+                        function=openai_compat.ToolCallFunction(
+                            name="delegate_task",
+                            arguments=json.dumps({"prompt": "shout text='hi'\nstop"}),
+                        ),
+                    )
+                ],
+            )
+        return openai_compat.Message(role="assistant", content="delegated")
+
+manager = TaskManager(agent_factory=lambda p=None: Agent(model=HTTPModel(), persona=p))
+main = Agent(model=DelegatingModel())
+
+task_id = manager.start_task("begin", main.runtime)
+while manager.status(task_id) == "running":
+    time.sleep(1)
+print("Status:", manager.status(task_id))
+```
+
+These snippets demonstrate different ways of integrating custom logic with Pygent. See the [examples](examples.md) directory for the full source code.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,5 +10,8 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) &ndash; registering a custom tool.
 - [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py) &ndash; delegating work to a background agent.
 - [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) &ndash; loading a config file and delegating a testing agent.
+- [delegate_external_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_external_tool.py) &ndash; new tool using an external model service inside a delegated task.
+
+See the [Custom Models](custom-models.md) page for a walkthrough of building your own models.
 
 Run these with `python <script>` from the project root. They expect the environment variables described in the [Configuration](configuration.md) page.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,7 +66,8 @@ available in the [Configuration](configuration.md) page.
 
 For full control you may pass a custom model implementation to `Agent`. The file
 [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py)
-contains a minimal echo model example.
+contains a minimal echo model example. A dedicated [Custom Models](custom-models.md)
+page expands on this topic with additional scenarios.
 
 ## Additional examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,8 @@ ag.runtime.cleanup()
 Custom models are supported by implementing the ``Model`` protocol and passing
 the instance to ``Agent``. They can also trigger tools by returning a message
 with ``tool_calls`` as shown in the ``custom_model_with_tool.py`` example.
+See the dedicated [Custom Models](custom-models.md) page for extended
+examples and advanced usage.
 
 ## Development
 

--- a/examples/delegate_external_tool.py
+++ b/examples/delegate_external_tool.py
@@ -1,0 +1,67 @@
+"""Delegate a task that uses a custom tool and an external model service."""
+import json
+import time
+from pygent import Agent, TaskManager, register_tool, Runtime, openai_compat
+
+
+def shout(rt: Runtime, text: str) -> str:
+    """Return the given text in uppercase."""
+    return text.upper()
+
+
+register_tool(
+    "shout",
+    "Uppercase some text",
+    {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+    shout,
+)
+
+
+class HTTPModel:
+    """Proxy requests to an OpenAI-compatible endpoint."""
+
+    def chat(self, messages, model, tools):
+        resp = openai_compat.chat.completions.create(
+            model=model, messages=messages, tools=tools, tool_choice="auto"
+        )
+        return resp.choices[0].message
+
+
+class DelegatingModel:
+    """Delegate once and stop."""
+
+    def __init__(self):
+        self.done = False
+
+    def chat(self, messages, model, tools):
+        if not self.done:
+            self.done = True
+            return openai_compat.Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    openai_compat.ToolCall(
+                        id="1",
+                        type="function",
+                        function=openai_compat.ToolCallFunction(
+                            name="delegate_task",
+                            arguments=json.dumps({"prompt": "shout text='hello'\nstop"}),
+                        ),
+                    )
+                ],
+            )
+        return openai_compat.Message(role="assistant", content="delegated")
+
+
+manager = TaskManager(agent_factory=lambda p=None: Agent(model=HTTPModel(), persona=p))
+main = Agent(model=DelegatingModel())
+
+# Launch the delegated task using the custom tool and external model
+task_id = manager.start_task("begin", main.runtime)
+print("Started", task_id)
+
+while manager.status(task_id) == "running":
+    time.sleep(1)
+
+print("Status:", manager.status(task_id))
+main.runtime.cleanup()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Getting Started: getting-started.md
   - Configuration: configuration.md
   - Examples: examples.md
+  - Custom Models: custom-models.md
   - API Reference: api-reference.md
 plugins:
   - search


### PR DESCRIPTION
## Summary
- add delegate_external_tool.py demonstrating custom tool, remote model and delegation
- document this new example on the Custom Models page
- link the example from the examples index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68635cd990bc8321877f656cec150fdb