### PR TITLE
Enable mkdocs dark theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.11'
       - name: Install docs deps
         run: |
-          pip install mkdocs
+          pip install mkdocs mkdocs-material
       - name: Build docs
         run: mkdocs build
       - name: Deploy docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,10 @@
 site_name: Pygent
 site_url: https://marianochaves.github.io/pygent/
 repo_url: https://github.com/marianochaves/pygent
-theme: readthedocs
+theme:
+  name: material
+  palette:
+    scheme: slate
 nav:
   - Home: index.md
   - Getting Started: getting-started.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest"]
-docs = ["mkdocs"]
+docs = ["mkdocs", "mkdocs-material"]
 docker = ["docker>=7.0.0"]
 ui = ["gradio"]
 


### PR DESCRIPTION
## Summary
- switch documentation theme to Material with dark mode
- include mkdocs-material in optional docs dependencies
- install mkdocs-material in CI

## Testing
- `pytest -q`
- `python -m mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68639757bf80832197af264a3a07b10a