### PR TITLE
Improve docs and theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,16 @@ repo_url: https://github.com/marianochaves/pygent
 theme:
   name: material
   palette:
-    scheme: slate
+    - scheme: default
+      primary: indigo
+      accent: indigo
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      media: '(prefers-color-scheme: dark)'
+  features:
+    - content.code.copy
+    - navigation.instant
 nav:
   - Home: index.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
## Summary
- rewrite API reference for clarity and include all built‑in tools
- add light/dark palettes and code copy button to theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686399a3a1188321901e6655f3a21451