### PR TITLE
Enable dark mode toggle and auto API docs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,86 +1,19 @@
 # API Reference
 
-This page describes the public classes and helpers provided by **Pygent**. Import everything from the package root unless noted otherwise.
+This section documents the main classes and helpers exposed by **Pygent**. The content is generated from the package docstrings.
 
-## `Agent`
+## Agent
 
-```python
-from pygent import Agent
-```
+::: pygent.agent.Agent
 
-`Agent` orchestrates the conversation with the selected model. Each instance owns a `Runtime` available as `agent.runtime`.
+## Runtime
 
-### Methods
+::: pygent.runtime.Runtime
 
-- `step(user_msg: str) -> pygent.openai_compat.Message` – add a message and run any tools returned by the model.
-- `run_interactive(use_docker: bool | None = None) -> None` – start a terminal session.
-- `run_gui(use_docker: bool | None = None) -> None` – launch the simple web interface.
-- `run_until_stop(user_msg: str, max_steps=20, ...) -> None` – keep executing steps until the `stop` tool is called or a limit is reached.
+## TaskManager
 
-## `Runtime`
+::: pygent.task_manager.TaskManager
 
-`Runtime` executes commands either locally or in a Docker container.
+## Tools
 
-### Methods
-
-- `bash(cmd: str, timeout: int = 30) -> str` – run a shell command and return its output.
-- `write_file(path: str, content: str) -> str` – create or overwrite a UTF‑8 file.
-- `read_file(path: str, binary: bool = False) -> str` – read a file from the workspace.
-- `cleanup() -> None` – destroy the temporary workspace and stop the container if one was used.
-
-## Built‑in tools
-
-These tools are registered automatically:
-
-- **bash** – run a command through `Runtime.bash`.
-- **write_file** – create files via `Runtime.write_file`.
-- **delegate_task** – start a background agent.
-- **delegate_persona_task** – like `delegate_task` but lets you pick the persona.
-- **list_personas** – return the available personas for delegation.
-- **task_status** – check the status of a delegated task.
-- **collect_file** – copy a file from a delegated task into the current workspace.
-- **download_file** – read a file using `Runtime.read_file`.
-- **continue** – request user input when running autonomously.
-- **stop** – stop the autonomous loop.
-
-Custom tools can be registered programmatically:
-
-```python
-from pygent import register_tool
-
-def hello(rt, name: str) -> str:
-    return f"Hello {name}!"
-
-register_tool(
-    "hello",
-    "Greet the user",
-    {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
-    hello,
-)
-```
-
-## `TaskManager`
-
-```python
-from pygent import TaskManager, Runtime
-```
-
-`TaskManager` launches separate agents asynchronously and tracks them. Pass a `Runtime` instance when starting a task so files can be copied into the sub‑agent's workspace.
-
-## Personas
-
-Agents can adopt different personas. The defaults come from the `PYGENT_PERSONA_NAME` and `PYGENT_PERSONA` environment variables. Delegated agent personas can be configured via `PYGENT_TASK_PERSONAS_JSON`. The `list_personas` tool returns all available options.
-
-## Custom prompts
-
-Provide a `Persona` object to the `Agent` constructor to override the system prompt:
-
-```python
-from pygent import Agent, Persona
-
-ag = Agent(persona=Persona("Helper", "a friendly bot"))
-```
-
-## Custom models
-
-`Agent` relies on an object implementing the `Model` protocol. The default `OpenAIModel` calls an OpenAI‑compatible API, but any backend can be plugged in. Custom models may return tool calls by filling the `tool_calls` attribute of the returned message.
+::: pygent.tools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,15 @@ theme:
     - scheme: default
       primary: indigo
       accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
     - scheme: slate
       primary: indigo
       accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
       media: '(prefers-color-scheme: dark)'
   features:
     - content.code.copy
@@ -23,3 +29,7 @@ nav:
   - API Reference: api-reference.md
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [pygent]

--- a/pygent/__main__.py
+++ b/pygent/__main__.py
@@ -1,3 +1,5 @@
+"""Executable module to support ``python -m pygent``."""
+
 from .cli import main
 
 if __name__ == "__main__":

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -24,10 +24,12 @@ DEFAULT_PERSONA = Persona(
 
 
 def build_system_msg(persona: Persona) -> str:
+    """Return the system prompt for ``persona``."""
+
     return (
         f"You are {persona.name}. {persona.description}\n"
         "Respond with JSON when you need to use a tool."
-        "If you need to stop or finished you task, call the `stop` tool.\n"
+        "If you need to stop or finish your task, call the `stop` tool.\n"
         "You can use the following tools:\n"
         f"{json.dumps(tools.TOOL_SCHEMAS, indent=2)}\n"
         "You can also use the `continue` tool to request user input or continue the conversation.\n"
@@ -47,6 +49,7 @@ def _default_model() -> Model:
 
 @dataclass
 class Agent:
+    """Interactive assistant handling messages and tool execution."""
     runtime: Runtime = field(default_factory=Runtime)
     model: Model = field(default_factory=_default_model)
     model_name: str = DEFAULT_MODEL
@@ -55,6 +58,7 @@ class Agent:
     history: List[Dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        """Initialize defaults after dataclass construction."""
         if not self.system_msg:
             self.system_msg = build_system_msg(self.persona)
         if not self.history:
@@ -134,6 +138,7 @@ class Agent:
 
 
 def run_interactive(use_docker: Optional[bool] = None) -> None:  # pragma: no cover
+    """Start an interactive session in the terminal."""
     agent = Agent(runtime=Runtime(use_docker=use_docker))
     console.print("[bold green]Pygent[/] iniciado. (digite /exit para sair)")
     try:

--- a/pygent/config.py
+++ b/pygent/config.py
@@ -1,4 +1,7 @@
+"""Utilities for loading configuration files."""
+
 import os
+
 import json
 try:  # Python 3.11+
     import tomllib  # type: ignore

--- a/pygent/openai_compat.py
+++ b/pygent/openai_compat.py
@@ -1,3 +1,5 @@
+"""Lightweight client compatible with the OpenAI HTTP API."""
+
 import os
 import json
 from dataclasses import dataclass

--- a/pygent/persona.py
+++ b/pygent/persona.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 @dataclass
 class Persona:
-    """Representa uma persona com nome e descricao."""
+    """Simple container for a persona name and description."""
     name: str
     description: str
 

--- a/pygent/ui.py
+++ b/pygent/ui.py
@@ -1,3 +1,5 @@
+"""Simple Gradio-based chat interface."""
+
 from .agent import Agent
 from .runtime import Runtime
 from .tools import execute_tool, TOOL_SCHEMAS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest"]
-docs = ["mkdocs", "mkdocs-material"]
+docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 docker = ["docker>=7.0.0"]
 ui = ["gradio"]
 


### PR DESCRIPTION
## Summary
- enable manual dark mode toggle via Material palette
- document packages automatically with mkdocstrings
- include mkdocstrings in docs dependencies
- fix minor typos and add docstrings

## Testing
- `pip install -e .[docs]`
- `mkdocs build`
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863b7ee49f8832197fe858a3b6d25c8