### PR TITLE
Add task listing and agent switching

### DIFF
--- a/pygent/task_manager.py
+++ b/pygent/task_manager.py
@@ -76,6 +76,20 @@ class TaskManager:
         self.tasks: Dict[str, Task] = {}
         self._lock = threading.Lock()
 
+    def list_tasks(self) -> Dict[str, Dict[str, str]]:
+        """Return ``task_id`` -> ``{"persona": name, "status": status}``."""
+        with self._lock:
+            return {
+                tid: {"persona": t.agent.persona.name, "status": t.status}
+                for tid, t in self.tasks.items()
+            }
+
+    def get_agent(self, task_id: str) -> Optional["Agent"]:
+        """Return the agent instance for ``task_id`` or ``None``."""
+        with self._lock:
+            task = self.tasks.get(task_id)
+        return task.agent if task else None
+
     def start_task(
         self,
         prompt: str,

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -224,6 +224,16 @@ def _task_status(rt: Runtime, task_id: str) -> str:
     return _get_manager().status(task_id)
 
 
+@tool(
+    name="list_tasks",
+    description="Return the available delegated tasks and their status.",
+    parameters={"type": "object", "properties": {}},
+)
+def _list_tasks(rt: Runtime) -> str:
+    """Return JSON mapping of task IDs to persona and status."""
+    return json.dumps(_get_manager().list_tasks())
+
+
 def _collect_file(rt: Runtime, task_id: str, path: str, dest: Optional[str] = None) -> str:
     """Retrieve a file or directory from a delegated task."""
     return _get_manager().collect_file(rt, task_id, path, dest)


### PR DESCRIPTION
## Summary
- add TaskManager.list_tasks and get_agent methods
- expose list_tasks via built-in tool
- improve CLI with task listing and agent switching
- test new task manager helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686494a072b883219905bb9b3980215b