### PR TITLE
Add conversation persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Integrates with OpenAI-compatible models to orchestrate each step.
 * Persists the conversation history during the session.
 * Optionally save the history to a JSON file for later recovery.
+* Persist the workspace across sessions by setting `PYGENT_WORKSPACE`.
 * Provides a small Python API for use in other projects.
 * Optional web interface via `pygent-ui`.
 * Register your own tools and customise the system prompt.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Runs commands in ephemeral containers (default image `python:3.12-slim`).
 * Integrates with OpenAI-compatible models to orchestrate each step.
 * Persists the conversation history during the session.
+* Optionally save the history to a JSON file for later recovery.
 * Provides a small Python API for use in other projects.
 * Optional web interface via `pygent-ui`.
 * Register your own tools and customise the system prompt.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
 | `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
 | `PYGENT_HISTORY_FILE` | Path to a JSON file where the conversation history is saved. | – |
+| `PYGENT_WORKSPACE` | Directory used to persist the workspace between sessions. | – |
 | `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |
 | `PYGENT_TASK_TIMEOUT` | Default overall time limit in seconds for delegated tasks. | – |
 | `PYGENT_PERSONA_NAME` | Name of the main agent persona. | `Pygent` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_IMAGE` | Docker image used for sandboxed execution. | `python:3.12-slim` |
 | `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
 | `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
+| `PYGENT_HISTORY_FILE` | Path to a JSON file where the conversation history is saved. | – |
 | `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |
 | `PYGENT_TASK_TIMEOUT` | Default overall time limit in seconds for delegated tasks. | – |
 | `PYGENT_PERSONA_NAME` | Name of the main agent persona. | `Pygent` |

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import uuid
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional
 
 from rich.console import Console
@@ -47,6 +47,11 @@ def _default_model() -> Model:
     return models.CUSTOM_MODEL or OpenAIModel()
 
 
+def _default_history_file() -> Optional[pathlib.Path]:
+    env = os.getenv("PYGENT_HISTORY_FILE")
+    return pathlib.Path(env) if env else None
+
+
 @dataclass
 class Agent:
     """Interactive assistant handling messages and tool execution."""
@@ -56,13 +61,46 @@ class Agent:
     persona: Persona = field(default_factory=lambda: DEFAULT_PERSONA)
     system_msg: str = field(default_factory=lambda: build_system_msg(DEFAULT_PERSONA))
     history: List[Dict[str, Any]] = field(default_factory=list)
+    history_file: Optional[pathlib.Path] = field(default_factory=_default_history_file)
 
     def __post_init__(self) -> None:
         """Initialize defaults after dataclass construction."""
         if not self.system_msg:
             self.system_msg = build_system_msg(self.persona)
+        if self.history_file and isinstance(self.history_file, (str, pathlib.Path)):
+            self.history_file = pathlib.Path(self.history_file)
+            if self.history_file.is_file():
+                try:
+                    with self.history_file.open("r", encoding="utf-8") as fh:
+                        data = json.load(fh)
+                except Exception:
+                    data = []
+                self.history = [
+                    openai_compat.parse_message(m) if isinstance(m, dict) else m
+                    for m in data
+                ]
         if not self.history:
-            self.history.append({"role": "system", "content": self.system_msg})
+            self.append_history({"role": "system", "content": self.system_msg})
+
+    def _message_dict(self, msg: Any) -> Dict[str, Any]:
+        if isinstance(msg, dict):
+            return msg
+        if isinstance(msg, openai_compat.Message):
+            data = {"role": msg.role, "content": msg.content}
+            if msg.tool_calls:
+                data["tool_calls"] = [asdict(tc) for tc in msg.tool_calls]
+            return data
+        raise TypeError(f"Unsupported message type: {type(msg)!r}")
+
+    def _save_history(self) -> None:
+        if self.history_file:
+            self.history_file.parent.mkdir(parents=True, exist_ok=True)
+            with self.history_file.open("w", encoding="utf-8") as fh:
+                json.dump([self._message_dict(m) for m in self.history], fh)
+
+    def append_history(self, msg: Any) -> None:
+        self.history.append(msg)
+        self._save_history()
 
     def refresh_system_message(self) -> None:
         """Update the system prompt based on the current tool registry."""
@@ -74,18 +112,18 @@ class Agent:
         """Execute one round of interaction with the model."""
 
         self.refresh_system_message()
-        self.history.append({"role": "user", "content": user_msg})
+        self.append_history({"role": "user", "content": user_msg})
 
         assistant_raw = self.model.chat(
             self.history, self.model_name, tools.TOOL_SCHEMAS
         )
         assistant_msg = openai_compat.parse_message(assistant_raw)
-        self.history.append(assistant_msg)
+        self.append_history(assistant_msg)
 
         if assistant_msg.tool_calls:
             for call in assistant_msg.tool_calls:
                 output = tools.execute_tool(call, self.runtime)
-                self.history.append(
+                self.append_history(
                     {"role": "tool", "content": output, "tool_call_id": call.id}
                 )
                 console.print(
@@ -127,7 +165,7 @@ class Agent:
         self._timed_out = False
         for _ in range(max_steps):
             if max_time is not None and time.monotonic() - start > max_time:
-                self.history.append(
+                self.append_history(
                     {"role": "system", "content": f"[timeout after {max_time}s]"}
                 )
                 self._timed_out = True
@@ -138,7 +176,7 @@ class Agent:
                 step_timeout is not None
                 and time.monotonic() - step_start > step_timeout
             ):
-                self.history.append(
+                self.append_history(
                     {"role": "system", "content": f"[timeout after {step_timeout}s]"}
                 )
                 self._timed_out = True

--- a/pygent/ui.py
+++ b/pygent/ui.py
@@ -21,15 +21,15 @@ def run_gui(use_docker: Optional[bool] = None) -> None:
     agent = Agent(runtime=Runtime(use_docker=use_docker))
 
     def _respond(message: str, history: Optional[list[tuple[str, str]]]) -> str:
-        agent.history.append({"role": "user", "content": message})
+        agent.append_history({"role": "user", "content": message})
         raw = agent.model.chat(agent.history, agent.model_name, TOOL_SCHEMAS)
         assistant_msg = openai_compat.parse_message(raw)
-        agent.history.append(assistant_msg)
+        agent.append_history(assistant_msg)
         reply = assistant_msg.content or ""
         if assistant_msg.tool_calls:
             for call in assistant_msg.tool_calls:
                 output = execute_tool(call, agent.runtime)
-                agent.history.append(
+                agent.append_history(
                     {"role": "tool", "content": output, "tool_call_id": call.id}
                 )
                 reply += f"\n\n[tool:{call.function.name}]\n{output}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.23"
+version = "0.1.24"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_history_persistence.py
+++ b/tests/test_history_persistence.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import types
+import json
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent, openai_compat
+
+class DummyModel:
+    def chat(self, messages, model, tools):
+        return openai_compat.Message(role='assistant', content='saved')
+
+class DummyRuntime:
+    def bash(self, cmd: str):
+        return f"ran {cmd}"
+    def write_file(self, path: str, content: str):
+        return f"wrote {path}"
+
+def test_history_saved_and_loaded(tmp_path):
+    path = tmp_path / 'hist.json'
+    ag = Agent(runtime=DummyRuntime(), model=DummyModel(), history_file=path)
+    ag.step('hello')
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert any(m.get('role') == 'assistant' for m in data)
+
+    ag2 = Agent(runtime=DummyRuntime(), model=DummyModel(), history_file=path)
+    assert any((m.role if hasattr(m, 'role') else m.get('role')) == 'assistant' for m in ag2.history)

--- a/tests/test_workspace_persistence.py
+++ b/tests/test_workspace_persistence.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# minimal rich mocks
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent.runtime import Runtime
+
+
+def test_persistent_workspace(tmp_path):
+    ws = tmp_path / 'ws'
+    rt = Runtime(use_docker=False, workspace=ws)
+    rt.write_file('foo.txt', 'bar')
+    rt.cleanup()
+    assert (ws / 'foo.txt').exists()
+
+    rt2 = Runtime(use_docker=False, workspace=ws)
+    assert rt2.read_file('foo.txt') == 'bar'
+    rt2.cleanup()
+    assert (ws / 'foo.txt').exists()


### PR DESCRIPTION
## Summary
- persist conversation history to JSON via `history_file` in `Agent`
- update UI to use new history persistence
- document new `PYGENT_HISTORY_FILE` setting and README bullet
- test saving and loading history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686497c1abb08321a26dad23dc7f1edb