### PR TITLE
Enhance CLI and optional task tools

### DIFF
--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -26,6 +26,7 @@ from .models import Model, OpenAIModel, set_custom_model  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool, clear_tools, reset_tools, remove_tool  # noqa: E402,F401
 from .task_manager import TaskManager  # noqa: E402,F401
+from .task_tools import register_task_tools  # noqa: E402,F401
 
 __all__ = [
     "Agent",
@@ -42,4 +43,5 @@ __all__ = [
     "reset_tools",
     "remove_tool",
     "TaskManager",
+    "register_task_tools",
 ]

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -8,9 +8,10 @@ def main() -> None:  # pragma: no cover
     parser.add_argument("--docker", dest="use_docker", action="store_true", help="run commands in a Docker container")
     parser.add_argument("--no-docker", dest="use_docker", action="store_false", help="run locally")
     parser.add_argument("-c", "--config", help="path to configuration file")
+    parser.add_argument("-w", "--workspace", help="name of workspace directory")
     parser.set_defaults(use_docker=None)
     args = parser.parse_args()
     load_config(args.config)
     from .agent import run_interactive
 
-    run_interactive(use_docker=args.use_docker)
+    run_interactive(use_docker=args.use_docker, workspace_name=args.workspace)

--- a/pygent/commands.py
+++ b/pygent/commands.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Simple command handlers for the interactive CLI."""
+
+from typing import Callable, Optional
+
+from .agent import Agent
+from .runtime import Runtime
+
+
+class Command:
+    """CLI command definition."""
+
+    def __init__(self, handler: Callable[[Agent, str], Optional[Agent]]):
+        self.handler = handler
+
+    def __call__(self, agent: Agent, arg: str) -> Optional[Agent]:
+        return self.handler(agent, arg)
+
+
+def cmd_cmd(agent: Agent, arg: str) -> None:
+    output = agent.runtime.bash(arg)
+    print(output)
+
+
+def cmd_cp(agent: Agent, arg: str) -> None:
+    parts = arg.split()
+    if not parts:
+        print("usage: /cp SRC [DEST]")
+        return
+    src = parts[0]
+    dest = parts[1] if len(parts) > 1 else None
+    msg = agent.runtime.upload_file(src, dest)
+    print(msg)
+
+
+def cmd_new(agent: Agent, arg: str) -> Agent:
+    persistent = agent.runtime._persistent
+    use_docker = agent.runtime.use_docker
+    workspace = agent.runtime.base_dir if persistent else None
+    agent.runtime.cleanup()
+    return Agent(runtime=Runtime(use_docker=use_docker, workspace=workspace))
+
+
+COMMANDS = {
+    "/cmd": Command(cmd_cmd),
+    "/cp": Command(cmd_cp),
+    "/new": Command(cmd_new),
+}

--- a/pygent/runtime.py
+++ b/pygent/runtime.py
@@ -32,13 +32,13 @@ class Runtime:
         env_ws = os.getenv("PYGENT_WORKSPACE")
         if workspace is None and env_ws:
             workspace = env_ws
-        if workspace:
-            self.base_dir = Path(workspace).expanduser()
-            self.base_dir.mkdir(parents=True, exist_ok=True)
-            self._persistent = True
-        else:
-            self.base_dir = Path(tempfile.mkdtemp(prefix="pygent_"))
+        if workspace is None:
+            self.base_dir = Path.cwd() / f"agent_{uuid.uuid4().hex[:8]}"
             self._persistent = False
+        else:
+            self.base_dir = Path(workspace).expanduser()
+            self._persistent = True
+        self.base_dir.mkdir(parents=True, exist_ok=True)
         if initial_files is None:
             env_files = os.getenv("PYGENT_INIT_FILES")
             if env_files:

--- a/pygent/task_manager.py
+++ b/pygent/task_manager.py
@@ -123,7 +123,8 @@ class TaskManager:
                 agent.runtime.cleanup()
             except Exception:
                 pass
-        agent.runtime = Runtime(use_docker=parent_rt.use_docker)
+        task_dir = parent_rt.base_dir / f"task_{uuid.uuid4().hex[:8]}"
+        agent.runtime = Runtime(use_docker=parent_rt.use_docker, workspace=task_dir)
         setattr(agent, "persona", persona)
         if not getattr(agent, "system_msg", None):
             from .agent import build_system_msg  # lazy import

--- a/pygent/task_tools.py
+++ b/pygent/task_tools.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+"""Optional tools for background tasks and personas."""
+
+import json
+from typing import Optional, List
+
+from .runtime import Runtime
+from .task_manager import TaskManager
+from .tools import register_tool
+
+_task_manager: Optional[TaskManager] = None
+
+
+def _get_manager() -> TaskManager:
+    global _task_manager
+    if _task_manager is None:
+        _task_manager = TaskManager()
+    return _task_manager
+
+
+# ---- tool implementations ----
+from .tools import (
+    _delegate_task,
+    _delegate_persona_task,
+    _list_personas,
+    _task_status,
+    _collect_file,
+    _download_file,
+)
+
+
+def register_task_tools() -> None:
+    """Register task-related tools."""
+    register_tool(
+        "delegate_task",
+        "Create a background task using a new agent and return its ID.",
+        {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "Instruction for the sub-agent"},
+                "files": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Files to copy to the sub-agent before starting",
+                },
+                "persona": {"type": "string", "description": "Persona for the sub-agent"},
+                "timeout": {"type": "number", "description": "Max seconds for the task"},
+                "step_timeout": {"type": "number", "description": "Time limit per step"},
+            },
+            "required": ["prompt"],
+        },
+        lambda rt, **kwargs: _delegate_task(rt, **kwargs),
+    )
+
+    register_tool(
+        "delegate_persona_task",
+        "Create a background task with a specific persona and return its ID.",
+        {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "Instruction for the sub-agent"},
+                "persona": {"type": "string", "description": "Persona for the sub-agent"},
+                "files": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Files to copy to the sub-agent before starting",
+                },
+                "timeout": {"type": "number", "description": "Max seconds for the task"},
+                "step_timeout": {"type": "number", "description": "Time limit per step"},
+            },
+            "required": ["prompt", "persona"],
+        },
+        lambda rt, **kwargs: _delegate_persona_task(rt, **kwargs),
+    )
+
+    register_tool(
+        "list_personas",
+        "Return the available personas for delegated agents.",
+        {"type": "object", "properties": {}},
+        lambda rt, **kwargs: _list_personas(rt, **kwargs),
+    )
+
+    register_tool(
+        "task_status",
+        "Check the status of a delegated task.",
+        {
+            "type": "object",
+            "properties": {"task_id": {"type": "string"}},
+            "required": ["task_id"],
+        },
+        lambda rt, **kwargs: _task_status(rt, **kwargs),
+    )
+
+    register_tool(
+        "collect_file",
+        "Retrieve a file or directory from a delegated task.",
+        {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "path": {"type": "string"},
+                "dest": {"type": "string"},
+            },
+            "required": ["task_id", "path"],
+        },
+        lambda rt, **kwargs: _collect_file(rt, **kwargs),
+    )
+
+    register_tool(
+        "download_file",
+        "Return the contents of a file from the workspace.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "binary": {"type": "boolean"},
+            },
+            "required": ["path"],
+        },
+        lambda rt, **kwargs: _download_file(rt, **kwargs),
+    )

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -116,25 +116,6 @@ def _continue(rt: Runtime) -> str:  # pragma: no cover - side-effect free
 
 
 
-@tool(
-    name="delegate_task",
-    description="Create a background task using a new agent and return its ID.",
-    parameters={
-        "type": "object",
-        "properties": {
-            "prompt": {"type": "string", "description": "Instruction for the sub-agent"},
-            "files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Files to copy to the sub-agent before starting",
-            },
-            "persona": {"type": "string", "description": "Persona for the sub-agent"},
-            "timeout": {"type": "number", "description": "Max seconds for the task"},
-            "step_timeout": {"type": "number", "description": "Time limit per step"},
-        },
-        "required": ["prompt"],
-    },
-)
 def _delegate_task(
     rt: Runtime,
     prompt: str,
@@ -160,25 +141,6 @@ def _delegate_task(
     return f"started {tid}"
 
 
-@tool(
-    name="delegate_persona_task",
-    description="Create a background task with a specific persona and return its ID.",
-    parameters={
-        "type": "object",
-        "properties": {
-            "prompt": {"type": "string", "description": "Instruction for the sub-agent"},
-            "persona": {"type": "string", "description": "Persona for the sub-agent"},
-            "files": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Files to copy to the sub-agent before starting",
-            },
-            "timeout": {"type": "number", "description": "Max seconds for the task"},
-            "step_timeout": {"type": "number", "description": "Time limit per step"},
-        },
-        "required": ["prompt", "persona"],
-    },
-)
 def _delegate_persona_task(
     rt: Runtime,
     prompt: str,
@@ -197,11 +159,6 @@ def _delegate_persona_task(
     )
 
 
-@tool(
-    name="list_personas",
-    description="Return the available personas for delegated agents.",
-    parameters={"type": "object", "properties": {}},
-)
 def _list_personas(rt: Runtime) -> str:
     """Return JSON list of personas."""
     personas = [
@@ -211,15 +168,6 @@ def _list_personas(rt: Runtime) -> str:
     return json.dumps(personas)
 
 
-@tool(
-    name="task_status",
-    description="Check the status of a delegated task.",
-    parameters={
-        "type": "object",
-        "properties": {"task_id": {"type": "string"}},
-        "required": ["task_id"],
-    },
-)
 def _task_status(rt: Runtime, task_id: str) -> str:
     return _get_manager().status(task_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.24"
+version = "0.1.25"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -31,6 +31,9 @@ from pygent.task_manager import TaskManager
 from pygent.persona import Persona
 from pygent.runtime import Runtime
 from pygent import tools
+from pygent.task_tools import register_task_tools
+
+register_task_tools()
 
 
 class DummyModel:


### PR DESCRIPTION
## Summary
- make task tools optional via `register_task_tools`
- add CLI command handlers for `/cmd`, `/cp` and `/new`
- allow naming the workspace folder and create workspaces under current dir
- improve agent system prompt
- adjust task runtime directories
- update tests for optional task tools
- bump version to 0.1.25

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865ba849fb08321b9ce4abcc3663d1e