### PR TITLE
Enhance CLI with Typer and history support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ After installing run:
 pygent
 ```
 
-Use `--docker` to run commands inside a container (requires
-`pygent[docker]`). Use `--no-docker` or set `PYGENT_USE_DOCKER=0`
-to force local execution. When the session starts the CLI shows the
-persona name and whether it is running locally or in Docker so you
-can easily tell which agent is active.
+The interface is implemented with [Typer](https://typer.tiangolo.com/), so
+`--help` lists all options. Use `--docker` to run commands inside a container
+(requires `pygent[docker]`) or `--no-docker` to force local execution. The CLI
+stores command history in `~/.pygent_history` and prints the persona name and
+whether it is running locally or in Docker when the session starts.
 Pass `--config path/to/pygent.toml` to load settings from a file.
 
 Type messages normally; use `/exit` to end the session. Each command is executed

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,10 +19,13 @@ Python 3.9 or newer is required. If Docker is not installed omit the
 
 ## Interactive session
 
-Start an interactive session by running `pygent` in a terminal. Use the
-`--docker` flag to force container execution or `--no-docker` to run locally.
-The CLI prints the persona name and whether commands run `local` or in
-`Docker` when the session starts so you know which agent is active.
+Start an interactive session by running `pygent` in a terminal. The command
+line interface is implemented with [Typer](https://typer.tiangolo.com/), so
+`--help` shows the available options. Use the `--docker` flag to force
+container execution or `--no-docker` to run locally. Command history is stored
+in `~/.pygent_history` and you can navigate previous inputs with the arrow
+keys. When the session starts the CLI prints the persona name and whether
+commands run `local` or in `Docker` so you know which agent is active.
 
 ```bash
 $ pygent --docker

--- a/pygent/__main__.py
+++ b/pygent/__main__.py
@@ -1,6 +1,6 @@
 """Executable module to support ``python -m pygent``."""
 
-from .cli import main
+from .cli import app
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -186,27 +186,12 @@ class Agent:
             msg = "continue"
 
 
-def run_interactive(use_docker: Optional[bool] = None, workspace_name: Optional[str] = None) -> None:  # pragma: no cover
+def run_interactive(
+    use_docker: Optional[bool] = None, workspace_name: Optional[str] = None
+) -> None:  # pragma: no cover
     """Start an interactive session in the terminal."""
-    ws = pathlib.Path.cwd() / workspace_name if workspace_name else None
-    agent = Agent(runtime=Runtime(use_docker=use_docker, workspace=ws))
-    from .commands import COMMANDS
-    mode = "Docker" if agent.runtime.use_docker else "local"
-    console.print(
-        f"[bold green]{agent.persona.name} ({mode})[/] iniciado. (digite /exit para sair)"
-    )
-    try:
-        while True:
-            user_msg = console.input("[cyan]user> [/]")
-            cmd = user_msg.split(maxsplit=1)[0]
-            args = user_msg[len(cmd):].strip() if " " in user_msg else ""
-            if cmd in {"/exit", "quit", "q"}:
-                break
-            if cmd in COMMANDS:
-                result = COMMANDS[cmd](agent, args)
-                if isinstance(result, Agent):
-                    agent = result
-                continue
-            agent.run_until_stop(user_msg)
-    finally:
-        agent.runtime.cleanup()
+
+    from .interactive import InteractiveSession
+
+    session = InteractiveSession(use_docker=use_docker, workspace=workspace_name)
+    session.start()

--- a/pygent/interactive.py
+++ b/pygent/interactive.py
@@ -1,0 +1,47 @@
+"""Interactive CLI session using prompt_toolkit."""
+from __future__ import annotations
+
+import pathlib
+from typing import Optional
+
+from rich.console import Console
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import FileHistory
+
+from .agent import Agent
+from .runtime import Runtime
+from .commands import COMMANDS
+
+
+class InteractiveSession:
+    """Handle user interaction in the terminal."""
+
+    def __init__(self, use_docker: Optional[bool] = None, workspace: Optional[str] = None) -> None:
+        ws = pathlib.Path.cwd() / workspace if workspace else None
+        self.agent = Agent(runtime=Runtime(use_docker=use_docker, workspace=ws))
+        history_path = pathlib.Path.home() / ".pygent_history"
+        self.session = PromptSession(history=FileHistory(str(history_path)))
+        self.console = Console()
+
+    def start(self) -> None:
+        mode = "Docker" if self.agent.runtime.use_docker else "local"
+        self.console.print(
+            f"[bold green]{self.agent.persona.name} ({mode})[/] iniciado. (digite /exit para sair)"
+        )
+        try:
+            while True:
+                user_msg = self.session.prompt("[cyan]user> ")
+                if not user_msg:
+                    continue
+                cmd = user_msg.split(maxsplit=1)[0]
+                args = user_msg[len(cmd):].strip() if " " in user_msg else ""
+                if cmd in {"/exit", "quit", "q"}:
+                    break
+                if cmd in COMMANDS:
+                    result = COMMANDS[cmd](self.agent, args)
+                    if isinstance(result, Agent):
+                        self.agent = result
+                    continue
+                self.agent.run_until_stop(user_msg)
+        finally:
+            self.agent.runtime.cleanup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "rich>=13.7.0",
     "openai>=1.0.0",
     "tomli; python_version < '3.11'",
+    "typer>=0.12.0",
+    "prompt_toolkit>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+import types
+import sys
+
+from typer.testing import CliRunner
+
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+from pygent import cli
+
+
+def test_cli_invokes_run_interactive(monkeypatch):
+    calls = []
+
+    def fake_run(use_docker=None, workspace_name=None):
+        calls.append((use_docker, workspace_name))
+
+    monkeypatch.setattr(cli, 'run_interactive', fake_run)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ['--no-docker', '--workspace', 'foo'])
+    assert result.exit_code == 0
+    assert calls == [(False, 'foo')]


### PR DESCRIPTION
## Summary
- replace argparse CLI with Typer
- implement `InteractiveSession` using prompt_toolkit
- delegate `run_interactive` to the new session
- update docs to mention Typer and history
- add simple CLI test
- include Typer and prompt_toolkit as dependencies

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c0245d5c8321ada9a3433051a745