### PR TITLE
Improve CLI with Typer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ in the container and the result shown in the terminal.
 Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
 For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
+Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 
 
 ## API usage

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Optionally save the history to a JSON file for later recovery.
 * Persist the workspace across sessions by setting `PYGENT_WORKSPACE`.
 * Provides a small Python API for use in other projects.
-* Optional web interface via `pygent-ui`.
+* Optional web interface via `pygent ui` (also available as `pygent-ui`).
 * Register your own tools and customise the system prompt.
 
 ## Installation
@@ -62,7 +62,7 @@ Type messages normally; use `/exit` to end the session. Each command is executed
 in the container and the result shown in the terminal.
 Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
-For a minimal web interface run `pygent-ui` instead (requires `pygent[ui]`).
+For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
 
 
 ## API usage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,9 +33,10 @@ Each message is executed in the sandbox and the output printed. Use `/exit`
 to leave the session. You can also launch a simple web interface with
 `pygent ui` (or the old `pygent-ui` script, requires the `ui` extra).
 
-Use `/help` inside the CLI to list available commands. The helper shows
-`/cmd` to run a raw shell command, `/cp` to copy files into the workspace
-and `/new` to restart the conversation while keeping the current runtime.
+Use `/help` inside the CLI to list available commands or `/help <cmd>`
+for details. The helper shows `/cmd` to run a raw shell command,
+`/cp` to copy files into the workspace and `/new` to restart the
+conversation while keeping the current runtime.
 
 ### Tool usage
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ vc> echo "Hello"
 
 Each message is executed in the sandbox and the output printed. Use `/exit`
 to leave the session. You can also launch a simple web interface with
-`pygent-ui` (requires the `ui` extra).
+`pygent ui` (or the old `pygent-ui` script, requires the `ui` extra).
 
 Use `/help` inside the CLI to list available commands. The helper shows
 `/cmd` to run a raw shell command, `/cp` to copy files into the workspace

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,8 @@ Python ≥ 3.9 is required. Docker is optional; install `pygent[docker]` to enab
 
 Start an interactive session by running `pygent` in the terminal. Use the `--docker` option to run commands in a container (requires `pygent[docker]`); otherwise they execute locally. Use `/exit` to quit.
 Pass `--config path/to/pygent.toml` to load settings from a file.
-Alternatively run `pygent-ui` for a simple web interface (requires `pygent[ui]`).
+Alternatively run `pygent ui` (or the legacy `pygent-ui` script) for a simple web interface
+(requires `pygent[ui]`).
 
 You can also use the Python API:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.1.26"
+version = "0.1.27"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "rich>=13.7.0",
     "openai>=1.0.0",
     "tomli; python_version < '3.11'",
+    "typer>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+# stub external dependencies
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.commands import cmd_help
+
+
+def test_help_lists_commands(capsys):
+    cmd_help(None, "")
+    captured = capsys.readouterr().out
+    assert "/cmd" in captured
+    assert "/cp" in captured
+    assert "quit the session" in captured
+
+
+def test_help_specific_command(capsys):
+    cmd_help(None, "/cmd")
+    captured = capsys.readouterr().out
+    assert "/cmd -" in captured
+


### PR DESCRIPTION
## Summary
- adopt Typer for the CLI
- add `pygent ui` command and `version` command
- document the new UI command
- include Typer as a dependency

## Testing
- `pip install typer==0.9.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686607aa32108321a43f37d73fcbe837