### PR TITLE
Fix persona system message initialization

### DIFF
--- a/pygent/task_manager.py
+++ b/pygent/task_manager.py
@@ -129,7 +129,7 @@ class TaskManager:
         if not getattr(agent, "system_msg", None):
             from .agent import build_system_msg  # lazy import
 
-            agent.system_msg = build_system_msg(persona)
+            agent.system_msg = build_system_msg(persona, getattr(agent, "disabled_tools", None))
         setattr(agent.runtime, "task_depth", parent_depth + 1)
         if files:
             for fp in files:

--- a/tests/test_persona_system_msg.py
+++ b/tests/test_persona_system_msg.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent
+from pygent.persona import Persona
+
+
+def test_agent_persona_system_msg():
+    persona = Persona("Tester", "a unit test persona")
+    ag = Agent(persona=persona)
+    assert f"You are {persona.name}. {persona.description}" in ag.system_msg


### PR DESCRIPTION
## Summary
- update `build_system_msg` to accept disabled tools
- rebuild default system message in `Agent.__post_init__`
- expose `disabled_tools` attribute on `Agent`
- ensure delegated agents rebuild system messages correctly
- test that system message reflects a custom persona

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686612d66c7c832189700c6f3d5ddc99