### PR TITLE
Implement snapshot loading and option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Provides a small Python API for use in other projects.
 * Optional web interface via `pygent ui` (also available as `pygent-ui`).
 * Register your own tools and customise the system prompt.
+* Extend the CLI with custom commands.
+* Execute a `config.py` script on startup for advanced configuration.
+* Set environment variables from the command line.
 
 ## Installation
 
@@ -64,6 +67,13 @@ Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
 For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
 Use `/help` for a list of built-in commands or `/help <cmd>` for details.
+Use `/save DIR` to snapshot the current environment for later use.
+Resume from a snapshot with `pygent --load DIR` or by setting
+`PYGENT_SNAPSHOT=DIR`.
+Additional commands can be registered programmatically with
+`pygent.commands.register_command()`.
+The CLI loads a `config.py` script if present (or passed with `--pyconfig`)
+and environment variables may be set directly with `-e NAME=value`.
 
 
 ## API usage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
 | `PYGENT_HISTORY_FILE` | Path to a JSON file where the conversation history is saved. | – |
 | `PYGENT_WORKSPACE` | Directory used to persist the workspace between sessions. | – |
+| `PYGENT_SNAPSHOT` | Load environment and history from the given directory on startup. | – |
 | `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |
 | `PYGENT_TASK_TIMEOUT` | Default overall time limit in seconds for delegated tasks. | – |
 | `PYGENT_PERSONA_NAME` | Name of the main agent persona. | `Pygent` |
@@ -47,6 +48,15 @@ You can also specify a configuration file explicitly when launching the CLI:
 ```bash
 pygent --config path/to/pygent.toml
 ```
+Environment variables can also be provided on the command line using
+the `-e` option:
+
+```bash
+pygent -e OPENAI_API_KEY=sk-... -e PYGENT_MODEL=gpt-4
+```
+If you need additional setup logic execute a Python file with
+`--pyconfig config.py`.
+To resume from a saved snapshot pass `--load DIR` or set `PYGENT_SNAPSHOT`.
 
 A practical example is included in
 [`examples/sample_config.toml`](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,9 @@ Use `/help` inside the CLI to list available commands or `/help <cmd>`
 for details. The helper shows `/cmd` to run a raw shell command,
 `/cp` to copy files into the workspace and `/new` to restart the
 conversation while keeping the current runtime.
+The `/save DIR` command copies the workspace and relevant configuration
+for later use.
+Resume the session with `pygent --load DIR`.
 
 ### Tool usage
 

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -2,7 +2,7 @@
 from importlib import metadata as _metadata
 from pathlib import Path
 
-from .config import load_config
+from .config import load_config, load_snapshot
 
 try:
     __version__: str = _metadata.version(__name__)
@@ -32,6 +32,7 @@ __all__ = [
     "Agent",
     "run_interactive",
     "load_config",
+    "load_snapshot",
     "Model",
     "OpenAIModel",
     "set_custom_model",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_custom_cli.py
+++ b/tests/test_custom_cli.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# minimal rich mocks
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.commands import register_command, COMMANDS
+from pygent.agent import Agent
+from pygent.runtime import Runtime
+
+
+def test_register_command_and_save(tmp_path, capsys):
+    def hello(agent, arg):
+        print('hello', arg)
+    register_command('/hello', hello, 'greet')
+    ag = Agent(runtime=Runtime(use_docker=False, workspace=tmp_path/'ws'))
+    COMMANDS['/hello'](ag, 'world')
+    captured = capsys.readouterr().out
+    assert 'hello world' in captured
+    # cleanup to avoid side effects
+    COMMANDS.pop('/hello')
+    ag.runtime.cleanup()

--- a/tests/test_load_snapshot.py
+++ b/tests/test_load_snapshot.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import types
+import json
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# minimal rich mocks
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent.config import load_snapshot
+from pygent.runtime import Runtime
+
+
+def test_load_snapshot_sets_env(tmp_path, monkeypatch):
+    snap = tmp_path / 'snap'
+    ws = snap / 'workspace'
+    ws.mkdir(parents=True)
+    (snap / 'env.json').write_text(json.dumps({'OPENAI_API_KEY': 'test'}))
+    (snap / 'history.json').write_text('[]')
+
+    saved = os.environ.copy()
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    load_snapshot(snap)
+    assert os.getenv('OPENAI_API_KEY') == 'test'
+    assert os.getenv('PYGENT_WORKSPACE') == str(ws)
+    assert os.getenv('PYGENT_HISTORY_FILE') == str(snap / 'history.json')
+
+    rt = Runtime(use_docker=False)
+    assert rt.base_dir == ws
+    rt.cleanup()
+    os.environ.clear()
+    os.environ.update(saved)

--- a/tests/test_pyconfig.py
+++ b/tests/test_pyconfig.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.config import run_py_config
+
+
+def test_run_py_config_sets_env(tmp_path, monkeypatch):
+    cfg = tmp_path / 'config.py'
+    cfg.write_text("import os\nos.environ['TEST_VAR']='ok'\n")
+    run_py_config(cfg)
+    assert os.getenv('TEST_VAR') == 'ok'
+    monkeypatch.delenv('TEST_VAR', raising=False)

--- a/tests/test_save_command.py
+++ b/tests/test_save_command.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.agent import Agent
+from pygent.runtime import Runtime
+from pygent.commands import cmd_save
+
+
+def test_cmd_save_creates_snapshot(tmp_path):
+    ag = Agent(runtime=Runtime(use_docker=False, workspace=tmp_path/'ws'))
+    ag.runtime.write_file('foo.txt', 'bar')
+    dest = tmp_path / 'save'
+    cmd_save(ag, str(dest))
+    assert (dest/'workspace'/'foo.txt').read_text() == 'bar'
+    assert (dest/'env.json').exists()
+    ag.runtime.cleanup()


### PR DESCRIPTION
## Summary
- introduce `load_snapshot` helper to restore saved sessions
- load snapshots at startup via `--load` or `PYGENT_SNAPSHOT`
- document new option in README and configuration docs
- bump package version to 0.2.1
- add unit test for snapshot loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686724637ec08321aad9f28c1385a1f5