### PR TITLE
Add banned command/app configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,8 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_TASK_PERSONAS` | List of personas for delegated agents separated by `os.pathsep`. | – |
 | `PYGENT_TASK_PERSONAS_JSON` | JSON array of persona objects with name and description for delegated agents. Overrides `PYGENT_TASK_PERSONAS` if set. | – |
 | `PYGENT_INIT_FILES` | List of files or directories copied into the workspace at startup, separated by `os.pathsep`. | – |
+| `PYGENT_BANNED_COMMANDS` | Commands that cannot be executed by the bash tool, separated by `os.pathsep`. | – |
+| `PYGENT_BANNED_APPS` | Applications that cannot appear in any command, separated by `os.pathsep`. | – |
 
 Instead of setting environment variables you can create a `pygent.toml` file in
 the current directory or in your home folder. Values defined there are loaded at

--- a/examples/sample_config.toml
+++ b/examples/sample_config.toml
@@ -7,3 +7,5 @@ name = "TestBot"
 description = "writes tests"
 
 initial_files = ["examples/welcome.txt"]
+banned_commands = ["rm"]
+banned_apps = ["python"]

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -16,7 +16,10 @@ try:
 except Exception:  # pragma: no cover - tests stub out rich
     box = None
 from contextlib import nullcontext
-import questionary
+try:  # pragma: no cover - optional dependency
+    import questionary  # type: ignore
+except Exception:  # pragma: no cover - used in tests without questionary
+    questionary = None
 
 from .runtime import Runtime
 from . import tools, models, openai_compat
@@ -267,7 +270,11 @@ def run_interactive(
                         options = args.get("options")
                         if options:
                             prompt = args.get("prompt", "Choose:")
-                            next_msg = questionary.select(prompt, choices=options).ask()
+                            if questionary:
+                                next_msg = questionary.select(prompt, choices=options).ask()
+                            else:  # pragma: no cover - simple fallback for tests
+                                opts = "/".join(options)
+                                next_msg = input(f"{prompt} ({opts}): ")
                         break
     finally:
         agent.runtime.cleanup()

--- a/pygent/config.py
+++ b/pygent/config.py
@@ -93,4 +93,16 @@ def load_config(path: Optional[Union[str, os.PathLike[str]]] = None) -> Dict[str
             )
         else:
             os.environ["PYGENT_INIT_FILES"] = str(config["initial_files"])
+    if "banned_commands" in config and "PYGENT_BANNED_COMMANDS" not in os.environ:
+        banned = config["banned_commands"]
+        if isinstance(banned, list):
+            os.environ["PYGENT_BANNED_COMMANDS"] = os.pathsep.join(str(c) for c in banned)
+        else:
+            os.environ["PYGENT_BANNED_COMMANDS"] = str(banned)
+    if "banned_apps" in config and "PYGENT_BANNED_APPS" not in os.environ:
+        apps = config["banned_apps"]
+        if isinstance(apps, list):
+            os.environ["PYGENT_BANNED_APPS"] = os.pathsep.join(str(a) for a in apps)
+        else:
+            os.environ["PYGENT_BANNED_APPS"] = str(apps)
     return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -60,3 +60,18 @@ def test_runtime_use_docker_property():
     finally:
         rt.cleanup()
 
+
+def test_banned_command_blocked():
+    rt = Runtime(use_docker=False, banned_commands=["rm"])
+    out = rt.bash("rm -rf foo")
+    rt.cleanup()
+    assert "command 'rm' disabled" in out
+
+
+def test_banned_app_blocked_env(monkeypatch):
+    monkeypatch.setenv("PYGENT_BANNED_APPS", "python")
+    rt = Runtime(use_docker=False)
+    out = rt.bash("python script.py")
+    rt.cleanup()
+    assert "application 'python' disabled" in out
+


### PR DESCRIPTION
## Summary
- allow specifying `banned_commands` and `banned_apps` via config or env vars
- block execution of banned items in `Runtime.bash`
- make `questionary` optional for tests
- document the new configuration variables
- provide example of the new settings
- test banning functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d87b248c8321a70304adb07e6b96