### PR TITLE
Add CLI log snapshots and tool management

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Use `--docker` to run commands inside a container (requires
 to force local execution. When the session starts the CLI shows the
 persona name and whether it is running locally or in Docker so you
 can easily tell which agent is active.
+Pass `--confirm-bash` if you want to approve each bash command before it runs.
+Use `--ban-cmd CMD` to disallow specific commands entirely (repeat to ban multiple).
 Pass `--config path/to/pygent.toml` to load settings from a file.
 
 Type messages normally; use `/exit` to end the session. Each command is executed
@@ -68,6 +70,8 @@ are not supported and will exit immediately.
 For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
 Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 Use `/save DIR` to snapshot the current environment for later use.
+Use `/tools` to enable or disable tools during the session.
+Use `/banned` to list or update banned commands.
 Resume from a snapshot with `pygent --load DIR` or by setting
 `PYGENT_SNAPSHOT=DIR`.
 Additional commands can be registered programmatically with

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,8 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_INIT_FILES` | List of files or directories copied into the workspace at startup, separated by `os.pathsep`. | – |
 | `PYGENT_BANNED_COMMANDS` | Commands that cannot be executed by the bash tool, separated by `os.pathsep`. | – |
 | `PYGENT_BANNED_APPS` | Applications that cannot appear in any command, separated by `os.pathsep`. | – |
+| `PYGENT_LOG_FILE` | Path to the CLI log file. | `workspace/cli.log` |
+| `PYGENT_CONFIRM_BASH` | Require confirmation before running bash commands (set to `1` to enable). | `0` |
 
 Instead of setting environment variables you can create a `pygent.toml` file in
 the current directory or in your home folder. Values defined there are loaded at

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,9 +37,14 @@ Use `/help` inside the CLI to list available commands or `/help <cmd>`
 for details. The helper shows `/cmd` to run a raw shell command,
 `/cp` to copy files into the workspace and `/new` to restart the
 conversation while keeping the current runtime.
-The `/save DIR` command copies the workspace and relevant configuration
-for later use.
-Resume the session with `pygent --load DIR`.
+Use `/tools` to enable or disable specific tools on the fly.
+Pass `--confirm-bash` when launching the CLI to require confirmation
+before running any `bash` command.
+Add `--ban-cmd NAME` to prevent certain commands entirely.
+The `/save DIR` command copies the workspace, the CLI log and relevant
+configuration for later use.  Resume the session with
+`pygent --load DIR`.
+Use `/banned` inside the CLI to list or modify the banned commands.
 
 ### Tool usage
 

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -56,6 +56,17 @@ def main(
         help="disable a specific tool",
         show_default=False,
     ),
+    confirm_bash: Optional[bool] = typer.Option(
+        None,
+        "--confirm-bash/--no-confirm-bash",
+        help="ask confirmation before running bash commands",
+    ),
+    ban_cmd: List[str] = typer.Option(
+        None,
+        "--ban-cmd",
+        help="command to ban (repeatable)",
+        show_default=False,
+    ),
 ) -> None:  # pragma: no cover - CLI wrapper
     """Start an interactive session when no subcommand is given."""
     load_config(config)
@@ -71,11 +82,23 @@ def main(
         run_py_config(pyconfig)
     else:
         run_py_config("config.py")
-    ctx.obj = {"docker": docker, "workspace": workspace, "omit_tool": omit_tool or []}
+    ctx.obj = {
+        "docker": docker,
+        "workspace": workspace,
+        "omit_tool": omit_tool or [],
+        "confirm_bash": confirm_bash,
+        "ban_cmd": ban_cmd or [],
+    }
     if ctx.invoked_subcommand is None:
         from .agent import run_interactive
 
-        run_interactive(use_docker=docker, workspace_name=workspace, disabled_tools=omit_tool or [])
+        run_interactive(
+            use_docker=docker,
+            workspace_name=workspace,
+            disabled_tools=omit_tool or [],
+            confirm_bash=confirm_bash,
+            banned_commands=ban_cmd or [],
+        )
         raise typer.Exit()
 
 

--- a/pygent/config.py
+++ b/pygent/config.py
@@ -35,6 +35,9 @@ def load_snapshot(path: Union[str, os.PathLike[str]]) -> Path:
     hist = dest / "history.json"
     if hist.is_file():
         os.environ["PYGENT_HISTORY_FILE"] = str(hist)
+    log = dest / "cli.log"
+    if log.is_file():
+        os.environ["PYGENT_LOG_FILE"] = str(log)
     return ws
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.2"
+version = "0.2.3"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]


### PR DESCRIPTION
## Summary
- require confirmation before running bash commands with `--confirm-bash`
- add `/tools` command to toggle tools at runtime
- save `cli.log` with `/save` and reload it with `--load`
- keep a CLI log file and auto-save workspace on crash
- allow banning commands via `--ban-cmd` and `/banned`
- document new options and bump version to 0.2.3

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68692a341ee083218d0b0c526aeb27d6