### PR TITLE
Update system prompt and rename continue tool

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,7 +10,7 @@ To start an interactive session, simply run `pygent` in your terminal. You can u
 * `--config <path>`: Loads configuration from a specific TOML file.
 * `--workspace <name>`: Defines a working directory for the session.
 * `--load <dir>`: Loads a snapshot of a previously saved environment, including the workspace, history, and environment variables.
-* `--confirm-bash`: Prompts for confirmation before executing any command with the `bash` tool.
+* `--confirm-bash`: Prompts for confirmation before executing any command with the `bash` tool. The command is shown in the terminal before asking for permission.
 * `--ban-cmd <command>`: Disables the execution of a specific command.
 
 ## Internal Commands

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_BANNED_COMMANDS` | Commands that cannot be executed by the bash tool, separated by `os.pathsep`. | – |
 | `PYGENT_BANNED_APPS` | Applications that cannot appear in any command, separated by `os.pathsep`. | – |
 | `PYGENT_LOG_FILE` | Path to the CLI log file. | `workspace/cli.log` |
-| `PYGENT_CONFIRM_BASH` | Require confirmation before running bash commands (set to `0` to disable). | `1` |
+| `PYGENT_CONFIRM_BASH` | Require confirmation before running bash commands (set to `0` to disable). When enabled, the command is displayed before prompting. | `1` |
 
 Instead of setting environment variables you can create a `pygent.toml` file in
 the current directory or in your home folder. Values defined there are loaded at

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_BANNED_COMMANDS` | Commands that cannot be executed by the bash tool, separated by `os.pathsep`. | – |
 | `PYGENT_BANNED_APPS` | Applications that cannot appear in any command, separated by `os.pathsep`. | – |
 | `PYGENT_LOG_FILE` | Path to the CLI log file. | `workspace/cli.log` |
-| `PYGENT_CONFIRM_BASH` | Require confirmation before running bash commands (set to `1` to enable). | `0` |
+| `PYGENT_CONFIRM_BASH` | Require confirmation before running bash commands (set to `0` to disable). | `1` |
 
 Instead of setting environment variables you can create a `pygent.toml` file in
 the current directory or in your home folder. Values defined there are loaded at

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,8 @@ for details. The helper shows `/cmd` to run a raw shell command,
 conversation while keeping the current runtime.
 Use `/tools` to enable or disable specific tools on the fly.
 Pass `--no-confirm-bash` if you want to skip the default confirmation
-before running any `bash` command.
+before running any `bash` command. When confirmation is enabled,
+the agent displays the command before asking for approval.
 Add `--ban-cmd NAME` to prevent certain commands entirely.
 The `/save DIR` command copies the workspace, the CLI log and relevant
 configuration for later use.  Resume the session with

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ for details. The helper shows `/cmd` to run a raw shell command,
 `/cp` to copy files into the workspace and `/new` to restart the
 conversation while keeping the current runtime.
 Use `/tools` to enable or disable specific tools on the fly.
-Pass `--confirm-bash` when launching the CLI to require confirmation
+Pass `--no-confirm-bash` if you want to skip the default confirmation
 before running any `bash` command.
 Add `--ban-cmd NAME` to prevent certain commands entirely.
 The `/save DIR` command copies the workspace, the CLI log and relevant

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,7 +11,7 @@ Pygent comes with a set of essential tools ready to use:
 * **`write_file`**: Creates or overwrites a file in the agent's workspace.
     * **Parameters**: `path` (string), `content` (string).
 * **`stop`**: Stops the agent's autonomous execution loop. Useful for signaling the end of a task.
-* **`continue`**: Used to request a response or input from the user, continuing the conversation.
+* **`ask_user`**: Used to request a response or input from the user, continuing the conversation.
 
 ## Task Tools
 

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -224,7 +224,14 @@ class Agent:
                 if self.confirm_bash and call.function.name == "bash":
                     args = json.loads(call.function.arguments or "{}")
                     cmd = args.get("cmd", "")
-                    prompt = f"Run command: {cmd}?"
+                    console.print(
+                        Panel(
+                            f"$ {cmd}",
+                            title=f"{self.persona.name} pending bash",
+                            box=box.ROUNDED if box else None,
+                        )
+                    )
+                    prompt = "Run this command?"
                     if questionary:
                         ok = questionary.confirm(prompt).ask()
                     else:  # pragma: no cover - fallback for tests

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import uuid
 import time
+import shutil
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional
 
@@ -33,24 +34,61 @@ DEFAULT_PERSONA = Persona(
 
 
 def build_system_msg(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
-    """Return the system prompt for ``persona`` with given tools."""
+    """Build the system prompt for ``persona`` with the active tools."""
 
+    # Active tool schemas
     schemas = [
-        s
-        for s in tools.TOOL_SCHEMAS
+        s for s in tools.TOOL_SCHEMAS
         if not disabled_tools or s["function"]["name"] not in disabled_tools
     ]
     has_bash = any(s["function"]["name"] == "bash" for s in schemas)
 
+    # 1) Dynamic prefix
+    try:
+        user = os.getlogin()
+    except Exception:
+        user = os.getenv("USER", "unknown")
+    dynamic_lines = [
+        f"User: {user}",
+        f"Working directory: {os.getcwd()}",
+    ]
+    if shutil.which("rg"):
+        dynamic_lines.append(
+            "Hint: prefer `rg` over `grep`/`ls -R`; it is faster and honours .gitignore."
+        )
+    dynamic_prefix = "\n".join(dynamic_lines)
+
+    # 2) Fixed operation block
+    fixed_block = (
+        "You are operating as and within a terminal-based coding assistant. "
+        "Your task is to satisfy the user's request with precision and safety. "
+        "When context is missing, rely on the available tools to inspect files or execute commands. "
+    )
+
+    # 3) Workflow block
+    workflow_block = (
+        "First, present a concise plan (≤ 5 lines) and end by asking the user permission to procceed."
+        "After approval, move step by step, briefly stating which tool you invoke and why. "
+        "If you require additional input, use the `ask_user` tool. "
+        "When the task is fully complete, use the `stop` tool."
+    )
+
+    # 4) Optional bash note
+    bash_note = (
+        "You can execute shell commands in an isolated environment via the `bash` tool, "
+        "including installing dependencies." if has_bash else ""
+    )
+
+    # 5) Tools block
+    tools_block = f"Available tools:\n{json.dumps(schemas, indent=2)}"
+
     return (
-        f"You are {persona.name}. {persona.description}\n"
-        "First, outline a short plan describing how you intend to solve the user's request."
-        " Present the plan and wait for approval before executing."
-        " Think step by step and use the available tools to solve the problem. "
-        f"{'You can run shell commands in a sandboxed environment using the `bash` tool. ' if has_bash else ''}"
-        "Call `stop` when your work is done. Use `continue` if you require user input.\n"
-        "Available tools:\n"
-        f"{json.dumps(schemas, indent=2)}\n"
+        f"{dynamic_prefix}\n\n"
+        f"{fixed_block}\n\n"
+        f"You are {persona.name}. {persona.description}\n\n"
+        f"{workflow_block}\n"
+        f"{bash_note}\n\n"
+        f"{tools_block}\n"
     )
 
 
@@ -76,7 +114,7 @@ def _default_log_file() -> Optional[pathlib.Path]:
 
 
 def _default_confirm_bash() -> bool:
-    return os.getenv("PYGENT_CONFIRM_BASH", "0") not in {"", "0", "false", "False"}
+    return os.getenv("PYGENT_CONFIRM_BASH", "1") not in {"", "0", "false", "False"}
 
 
 @dataclass
@@ -214,7 +252,7 @@ class Agent:
                 self.append_history(
                     {"role": "tool", "content": output, "tool_call_id": call.id}
                 )
-                if call.function.name not in {"continue", "stop"}:
+                if call.function.name not in {"ask_user", "stop"}:
                     console.print(
                         Panel(
                             output,
@@ -275,9 +313,9 @@ class Agent:
                 self._timed_out = True
                 break
             calls = assistant_msg.tool_calls or []
-            if any(c.function.name in ("stop", "continue") for c in calls):
+            if any(c.function.name in ("stop", "ask_user") for c in calls):
                 break
-            msg = "continue"
+            msg = "ask_user"
 
         return last_msg
 
@@ -336,7 +374,7 @@ def run_interactive(
             last = agent.run_until_stop(user_msg)
             if last and last.tool_calls:
                 for call in last.tool_calls:
-                    if call.function.name == "continue":
+                    if call.function.name == "ask_user":
                         args = json.loads(call.function.arguments or "{}")
                         options = args.get("options")
                         if options:

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -106,7 +106,7 @@ def _stop(rt: Runtime) -> str:  # pragma: no cover - side-effect free
 
 
 @tool(
-    name="continue",
+    name="ask_user",
     description=(
         "Request user answer or input. If in your previous message you asked for user"
         " input, you can use this tool to continue the conversation. Optionally"
@@ -128,7 +128,7 @@ def _stop(rt: Runtime) -> str:  # pragma: no cover - side-effect free
         "required": [],
     },
 )
-def _continue(
+def _ask_user(
     rt: Runtime, prompt: str | None = None, options: Optional[list[str]] = None
 ) -> str:  # pragma: no cover - side-effect free
     return "Continuing the conversation."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.5"
+version = "0.2.6"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution. See https://marianochaves.github.io/pygent for documentation and https://github.com/marianochaves/pygent for the source code."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_autorun.py
+++ b/tests/test_autorun.py
@@ -72,7 +72,7 @@ class DummyRuntime:
 
 
 def test_run_until_stop():
-    ag = Agent(runtime=DummyRuntime(), model=DummyModel())
+    ag = Agent(runtime=DummyRuntime(), model=DummyModel(), confirm_bash=False)
     ag.run_until_stop('start', max_steps=5)
     assert any(call.function.name == 'stop'
                for msg in ag.history

--- a/tests/test_custom_model_tool.py
+++ b/tests/test_custom_model_tool.py
@@ -47,6 +47,6 @@ class DummyRuntime:
 
 
 def test_custom_model_tool():
-    ag = Agent(runtime=DummyRuntime(), model=BashModel())
+    ag = Agent(runtime=DummyRuntime(), model=BashModel(), confirm_bash=False)
     ag.step('run')
     assert any(isinstance(m, dict) and m.get('role') == 'tool' for m in ag.history)

--- a/tests/test_dict_model.py
+++ b/tests/test_dict_model.py
@@ -49,6 +49,6 @@ class DummyRuntime:
 
 
 def test_dict_model_tool():
-    ag = Agent(runtime=DummyRuntime(), model=DictModel())
+    ag = Agent(runtime=DummyRuntime(), model=DictModel(), confirm_bash=False)
     ag.step("run")
     assert any(isinstance(m, dict) and m.get("role") == "tool" for m in ag.history)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -91,8 +91,8 @@ def test_remove_tool_updates_prompt():
     reset_tools()
 
 
-def test_continue_tool_schema_allows_options():
-    schema = [s for s in tools.TOOL_SCHEMAS if s["function"]["name"] == "continue"][0]
+def test_ask_user_tool_schema_allows_options():
+    schema = [s for s in tools.TOOL_SCHEMAS if s["function"]["name"] == "ask_user"][0]
     props = schema["function"]["parameters"]["properties"]
     assert "options" in props
 


### PR DESCRIPTION
## Summary
- enhance `build_system_msg` with dynamic prefix and workflow description
- rename `continue` tool to `ask_user`
- enable bash confirmation by default
- adjust docs and tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cd3063f08321b49809e73c69132a