### PR TITLE
Fix unit tests

### DIFF
--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -13,6 +13,14 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.markdown import Markdown
 try:
+    from rich import __version__ as _rich_version  # noqa: F401
+except Exception:  # pragma: no cover - tests may stub out rich
+    import rich as _rich
+    if not hasattr(_rich, "__version__"):
+        _rich.__version__ = "0"
+    if not hasattr(_rich, "__file__"):
+        _rich.__file__ = "rich-not-installed"
+try:
     from rich import box  # type: ignore
 except Exception:  # pragma: no cover - tests stub out rich
     box = None


### PR DESCRIPTION
## Summary
- make rich imports optional in `commands` and `agent`
- add graceful fallback for `/help` output when rich is absent
- fix `register_command` signature and fallback output format
- ensure stubbed rich modules include `__version__` and `__file__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a085340ec832192f885e9bb9a613b