### PR TITLE
Add OS info to system prompt

### DIFF
--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -6,6 +6,7 @@ import pathlib
 import uuid
 import time
 import shutil
+import platform
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional
 
@@ -58,6 +59,7 @@ def build_system_msg(persona: Persona, disabled_tools: Optional[List[str]] = Non
         user = os.getenv("USER", "unknown")
     dynamic_lines = [
         f"User: {user}",
+        f"OS: {platform.system()}",
         f"Working directory: {os.getcwd()}",
     ]
     if shutil.which("rg"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.8"
+version = "0.2.9"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]


### PR DESCRIPTION
## Summary
- include the current operating system in the generated system prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b1a749ef08321af317108869f19f5