### PR TITLE
Allow custom system prompt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ set_custom_model(MyModel())
 
 All new agents and delegated tasks will use this model unless another one is passed explicitly.
 
+You can also override how the assistant builds the system prompt:
+
+```python
+from pygent.agent import set_system_message_builder
+
+def my_builder(persona, disabled_tools=None):
+    return f"{persona.name}: ready to work"
+
+set_system_message_builder(my_builder)
+```
+
+Passing `None` restores the default prompt generation.
+
 ### Using OpenAI and other providers
 
 Set your OpenAI key:

--- a/docs/custom-system-message.md
+++ b/docs/custom-system-message.md
@@ -1,0 +1,23 @@
+# Custom System Message
+
+Pygent builds the initial system prompt dynamically based on the persona
+and the currently active tools. If you want full control over this
+message you can supply your own builder function.
+
+Use `set_system_message_builder` to register a callable that returns the
+system prompt. A convenient place to do this is in a `config.py` file
+loaded on start-up.
+
+```python
+# config.py
+from pygent.agent import set_system_message_builder
+
+
+def my_system_builder(persona, disabled_tools=None):
+    return f"{persona.name}: ready to work"
+
+set_system_message_builder(my_system_builder)
+```
+
+Pass `None` to `set_system_message_builder` to restore the default
+prompt generation logic.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Configuration: configuration.md
   - Tools: tools.md
   - Custom Models: custom-models.md
+  - Custom System Message: custom-system-message.md
   - Architecture: architecture.md
   - Examples: examples.md
   - API Reference: api-reference.md

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -21,7 +21,11 @@ except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for tests
     else:
         __version__ = "0.0.0"
 
-from .agent import Agent, run_interactive  # noqa: E402,F401, must come after __version__
+from .agent import (
+    Agent,
+    run_interactive,
+    set_system_message_builder,
+)
 from .models import Model, OpenAIModel, set_custom_model  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool, clear_tools, reset_tools, remove_tool  # noqa: E402,F401
@@ -36,6 +40,7 @@ __all__ = [
     "Model",
     "OpenAIModel",
     "set_custom_model",
+    "set_system_message_builder",
     "PygentError",
     "APIError",
     "register_tool",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.10"
+version = "0.2.11"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_pyconfig.py
+++ b/tests/test_pyconfig.py
@@ -29,3 +29,19 @@ def test_run_py_config_sets_env(tmp_path, monkeypatch):
     run_py_config(cfg)
     assert os.getenv('TEST_VAR') == 'ok'
     monkeypatch.delenv('TEST_VAR', raising=False)
+
+
+def test_run_py_config_sets_system_builder(tmp_path):
+    cfg = tmp_path / 'config.py'
+    cfg.write_text(
+        'from pygent.agent import set_system_message_builder\n'
+        'def b(p, disabled_tools=None):\n'
+        '    return "CUSTOM"\n'
+        'set_system_message_builder(b)\n'
+    )
+    run_py_config(cfg)
+    from pygent.agent import Agent, set_system_message_builder
+
+    ag = Agent()
+    assert ag.system_msg == "CUSTOM"
+    set_system_message_builder(None)


### PR DESCRIPTION
## Summary
- export `set_system_message_builder`
- allow overriding `build_system_msg`
- test custom builder through `config.py`
- document new functionality and add docs page
- bump version to 0.2.11

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be0ebdaec832189f2acddf96bbebe