### PR TITLE
Improve tool error handling and bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.11"
+version = "0.2.12"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -75,6 +75,29 @@ def test_register_and_execute_custom_tool():
     assert tools.execute_tool(call, DummyRuntime()) == 'hi bob'
 
 
+def test_execute_tool_handles_exception():
+    def boom(rt):
+        raise RuntimeError('fail')
+
+    register_tool(
+        "boom",
+        "fail",
+        {"type": "object", "properties": {}},
+        lambda rt: boom(rt),
+    )
+
+    call = type('Call', (), {
+        'function': type('Func', (), {
+            'name': 'boom',
+            'arguments': '{}'
+        })
+    })()
+
+    out = tools.execute_tool(call, DummyRuntime())
+    assert 'error' in out.lower()
+    remove_tool('boom')
+
+
 def test_clear_and_reset_tools_updates_prompt():
     clear_tools()
     ag = Agent()


### PR DESCRIPTION
## Summary
- catch and report exceptions from custom tools
- test that failing tools don't crash CLI
- bump version to 0.2.12

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c537bc3f08321ba09073dd5c440e1