### PR TITLE
Add crew-style multi-agent docs

### DIFF
--- a/docs/crew-style.md
+++ b/docs/crew-style.md
@@ -1,0 +1,59 @@
+# Multi-Agent Collaboration
+
+Pygent pode coordenar diversos agentes em paralelo por meio da classe `TaskManager`. Essa abordagem lembra sistemas como o Crew AI, em que tarefas são distribuídas para agentes especializados.
+
+## Definindo personas
+
+Crie uma lista de `Persona` para representar os papéis dos agentes que irão compor a "equipe":
+
+```python
+from pygent import Agent, TaskManager
+from pygent.persona import Persona
+
+personas = [
+    Persona("escritor", "produz arquivos"),
+    Persona("revisor", "analisa o resultado"),
+]
+
+manager = TaskManager(personas=personas)
+```
+
+## Delegando tarefas
+
+Use `start_task` para lançar subtarefas em background. Defina a persona desejada e, opcionalmente, envie arquivos de apoio:
+
+```python
+main = Agent()
+
+# Envie um agente escritor para gerar um arquivo
+escrita = manager.start_task(
+    "write_file path='nota.txt' content='ola'\nstop",
+    main.runtime,
+    persona="escritor",
+)
+
+# Outro agente lê o arquivo e imprime no console
+leitura = manager.start_task(
+    "bash cmd='cat nota.txt'\nstop",
+    main.runtime,
+    files=["nota.txt"],
+    persona="revisor",
+)
+```
+
+## Acompanhar e coletar resultados
+
+O `TaskManager` permite verificar o status e copiar arquivos de volta para o agente principal:
+
+```python
+import time
+for tid in [escrita, leitura]:
+    while manager.status(tid) == "running":
+        time.sleep(1)
+    print("Status da tarefa", tid + ":", manager.status(tid))
+
+print(manager.collect_file(main.runtime, escrita, "nota.txt"))
+main.runtime.cleanup()
+```
+
+Com essas chamadas é possível montar fluxos de trabalho em cadeia ou paralelos, obtendo um comportamento semelhante ao de frameworks de múltiplos agentes como o Crew AI.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,6 +11,7 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py) &ndash; delegating work to a background agent.
 - [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) &ndash; loading a config file and delegating a testing agent.
 - [delegate_external_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_external_tool.py) &ndash; new tool using an external model service inside a delegated task.
+- [crew_example.py](https://github.com/marianochaves/pygent/blob/main/examples/crew_example.py) &ndash; coordenando dois agentes em paralelo.
 
 See the [Custom Models](custom-models.md) page for a walkthrough of building your own models.
 

--- a/examples/crew_example.py
+++ b/examples/crew_example.py
@@ -1,0 +1,35 @@
+"""Coordenar dois subagentes em paralelo."""
+import time
+from pygent import Agent, TaskManager
+from pygent.persona import Persona
+
+personas = [
+    Persona("escritor", "produz arquivos"),
+    Persona("revisor", "analisa o resultado"),
+]
+
+manager = TaskManager(personas=personas)
+main = Agent()
+
+# Agente 1 escreve um arquivo
+escrita = manager.start_task(
+    "write_file path='nota.txt' content='ola'\nstop",
+    main.runtime,
+    persona="escritor",
+)
+
+# Agente 2 lê o arquivo
+leitura = manager.start_task(
+    "bash cmd='cat nota.txt'\nstop",
+    main.runtime,
+    files=["nota.txt"],
+    persona="revisor",
+)
+
+for tid in [escrita, leitura]:
+    while manager.status(tid) == "running":
+        time.sleep(1)
+    print(tid, manager.status(tid))
+
+print(manager.collect_file(main.runtime, escrita, "nota.txt"))
+main.runtime.cleanup()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - Tools: tools.md
   - Custom Models: custom-models.md
   - Custom System Message: custom-system-message.md
+  - Multi-Agent Collaboration: crew-style.md
   - Architecture: architecture.md
   - Examples: examples.md
   - API Reference: api-reference.md


### PR DESCRIPTION
## Summary
- document how to coordinate sub-agents using `TaskManager`
- add `crew_example.py` demonstration script
- include the new example in the docs
- list new page in `mkdocs.yml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c70f8c21c83218d4c97e2ab5d6839