### PR TITLE
Improve prompt workflow block

### DIFF
--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -91,12 +91,31 @@ def build_system_msg(persona: Persona, disabled_tools: Optional[List[str]] = Non
     )
 
     # 3) Workflow block
-    workflow_block = (
-        "First, present a concise plan (≤ 5 lines) and end by asking the user permission to procceed."
-        "After approval, move step by step, briefly stating which tool you invoke and why. "
-        "If you require additional input, use the `ask_user` tool. "
-        "When the task is fully complete, use the `stop` tool."
+    has_ask = any(s["function"]["name"] == "ask_user" for s in schemas)
+    has_stop = any(s["function"]["name"] == "stop" for s in schemas)
+
+    first_line = "First, present a concise plan (≤ 5 lines)"
+    if has_ask:
+        first_line += " and end by asking the user permission to procceed."
+    else:
+        first_line += "."
+
+    second_line = (
+        "After approval, move step by step, briefly stating which tool you invoke and why."
+        if has_ask
+        else "Then move step by step, briefly stating which tool you invoke and why."
     )
+
+    workflow_parts = [first_line, second_line]
+    if has_ask:
+        workflow_parts.append("If you require additional input, use the `ask_user` tool.")
+    workflow_parts.append(
+        "Before finalizing, verify and test that the request is fully satisfied. "
+        "If not, keep iterating until no more improvements can be made."
+    )
+    if has_stop:
+        workflow_parts.append("When the task is fully complete, use the `stop` tool.")
+    workflow_block = " ".join(workflow_parts)
 
     # 4) Optional bash note
     bash_note = (

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -129,3 +129,32 @@ def test_read_image_data_url(tmp_path):
     assert result.startswith("data:image/png;base64,")
 
 
+def test_workflow_block_respects_ask_user():
+    reset_tools()
+    ag = Agent()
+    assert "ask_user" in ag.system_msg
+    assert "procceed" in ag.system_msg
+
+    remove_tool("ask_user")
+    ag2 = Agent()
+    assert "ask_user" not in ag2.system_msg
+    assert "procceed" not in ag2.system_msg
+    reset_tools()
+
+
+def test_workflow_block_respects_stop_tool():
+    reset_tools()
+    ag = Agent()
+    assert "stop" in ag.system_msg
+
+    remove_tool("stop")
+    ag2 = Agent()
+    assert "stop" not in ag2.system_msg
+    reset_tools()
+
+
+def test_workflow_block_includes_review_instruction():
+    ag = Agent()
+    assert "verify and test" in ag.system_msg
+
+


### PR DESCRIPTION
## Summary
- mention asking user permission only if `ask_user` tool is active
- only mention `stop` in workflow if tool is available
- prompt instructs the assistant to verify task completion via testing before finalizing
- test workflow prompt respects ask/stop tool availability
- test workflow prompt mentions task review

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c714f17bc8321bf3c735a4862726a