### PR TITLE
Add command to toggle bash confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 Use `/save DIR` to snapshot the current environment for later use.
 Use `/tools` to enable or disable tools during the session.
 Use `/banned` to list or update banned commands.
+Use `/confirm-bash on|off` to toggle confirmation before running bash commands.
 Resume from a snapshot with `pygent --load DIR` or by setting
 `PYGENT_SNAPSHOT=DIR`.
 Additional commands can be registered programmatically with

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,4 +24,5 @@ Within the interactive session, you can use the following commands that start wi
 * `/save <dir>`: Saves the current state, including the workspace, conversation history, and environment variables, to a directory for later use.
 * `/tools [list|enable|disable <name>]`: Lists available tools or enables/disables a specific tool during the session.
 * `/banned [list|add|remove <name>]`: Lists, adds, or removes commands from the list of banned commands in the `runtime`.
+* `/confirm-bash [on|off]`: Enables or disables confirmation before running `bash` commands during the session.
 * `/exit`: Ends the interactive session.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,7 @@ Use `/tools` to enable or disable specific tools on the fly.
 Pass `--no-confirm-bash` if you want to skip the default confirmation
 before running any `bash` command. When confirmation is enabled,
 the agent displays the command before asking for approval.
+You can toggle this behaviour at runtime with `/confirm-bash on|off`.
 Add `--ban-cmd NAME` to prevent certain commands entirely.
 The `/save DIR` command copies the workspace, the CLI log and relevant
 configuration for later use.  Resume the session with

--- a/pygent/commands.py
+++ b/pygent/commands.py
@@ -184,6 +184,20 @@ def cmd_banned(agent: Agent, arg: str) -> None:
             print(f"{name} not banned")
 
 
+def cmd_confirm_bash(agent: Agent, arg: str) -> None:
+    """Show or toggle confirmation for bash commands."""
+    arg = arg.strip().lower()
+    if not arg:
+        status = "on" if agent.confirm_bash else "off"
+        print(status)
+        return
+    if arg not in {"on", "off"}:
+        print("usage: /confirm-bash [on|off]")
+        return
+    agent.confirm_bash = arg == "on"
+    print("confirmation " + ("enabled" if agent.confirm_bash else "disabled"))
+
+
 def register_command(
     name: str,
     handler: Callable[[Agent, str], Optional[Agent]],
@@ -204,4 +218,5 @@ COMMANDS: Dict[str, Command] = {
     "/save": Command(cmd_save, description="Save workspace and environment to DIR for later use.", usage="/save DIR"),
     "/tools": Command(cmd_tools, description="Enable/disable tools at runtime or list them.", usage="/tools [list|enable NAME|disable NAME]"),
     "/banned": Command(cmd_banned, description="List or modify banned commands.", usage="/banned [list|add CMD|remove CMD]"),
+    "/confirm-bash": Command(cmd_confirm_bash, description="Toggle confirmation before running bash commands.", usage="/confirm-bash [on|off]"),
 }

--- a/tests/test_confirm_bash_command.py
+++ b/tests/test_confirm_bash_command.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.agent import Agent
+from pygent.runtime import Runtime
+from pygent.commands import cmd_confirm_bash
+
+
+def test_cmd_confirm_bash_toggle(tmp_path, capsys):
+    ag = Agent(runtime=Runtime(use_docker=False, workspace=tmp_path / 'ws'))
+    cmd_confirm_bash(ag, '')
+    assert ('on' in capsys.readouterr().out.lower()) == ag.confirm_bash
+    cmd_confirm_bash(ag, 'off')
+    assert ag.confirm_bash is False
+    assert 'disabled' in capsys.readouterr().out.lower()
+    cmd_confirm_bash(ag, 'on')
+    assert ag.confirm_bash is True
+    assert 'enabled' in capsys.readouterr().out.lower()
+    ag.runtime.cleanup()


### PR DESCRIPTION
## Summary
- add `/confirm-bash` command
- document command in README and docs
- mention runtime toggling in getting started guide
- test new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7ba3dbf88321abb276cb1aafaca8