### PR TITLE
Add agent presets CLI option

### DIFF
--- a/docs/agent-presets.md
+++ b/docs/agent-presets.md
@@ -1,0 +1,31 @@
+# Agent Presets
+
+The :mod:`pygent.agent_presets` module bundles ready-made configurations for common
+workflows. Each preset combines a system message builder from the
+:mod:`pygent.prompt_library` with a default set of tools.
+
+Use :data:`~pygent.agent_presets.AGENT_PRESETS` to select one:
+
+```python
+from pygent import AGENT_PRESETS
+
+ag = AGENT_PRESETS["autonomous"].create_agent()
+ag.run_until_stop("echo hello")
+```
+
+The available presets and their behaviours are:
+
+| Name | Tools | Description |
+| --- | --- | --- |
+| ``autonomous`` | ``bash``, ``write_file``, ``stop`` | Runs without user interaction and finishes with ``stop``. |
+| ``assistant`` | ``bash``, ``write_file``, ``ask_user`` | Interactive style that asks for clarifications. |
+| ``reviewer`` | ``bash`` | Focuses on analysing code and suggesting improvements. |
+
+You can create your own preset by instantiating
+:class:`~pygent.agent_presets.AgentPreset` with a custom builder and tool list.
+
+To start an interactive session using a preset from the command line:
+
+```bash
+pygent --preset autonomous
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,6 +12,8 @@ To start an interactive session, simply run `pygent` in your terminal. You can u
 * `--load <dir>`: Loads a snapshot of a previously saved environment, including the workspace, history, and environment variables.
 * `--confirm-bash`: Prompts for confirmation before executing any command with the `bash` tool. The command is shown in the terminal before asking for permission.
 * `--ban-cmd <command>`: Disables the execution of a specific command.
+* `--preset <name>`: Starts the session using one of the built-in presets
+  (`autonomous`, `assistant`, or `reviewer`).
 
 ## Internal Commands
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,8 @@ This page collects small scripts demonstrating different aspects of Pygent. Each
 - [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) &ndash; loading a config file and delegating a testing agent.
 - [delegate_external_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_external_tool.py) &ndash; new tool using an external model service inside a delegated task.
 - [crew_example.py](https://github.com/marianochaves/pygent/blob/main/examples/crew_example.py) &ndash; coordenando dois agentes em paralelo.
+- [prompt_library.py](https://github.com/marianochaves/pygent/blob/main/examples/prompt_library.py) &ndash; using the prebuilt system message builders.
+- [agent_presets.py](https://github.com/marianochaves/pygent/blob/main/examples/agent_presets.py) &ndash; launching an agent from a preset.
 
 See the [Custom Models](custom-models.md) page for a walkthrough of building your own models.
 

--- a/docs/prompt-library.md
+++ b/docs/prompt-library.md
@@ -1,0 +1,29 @@
+# Prompt Library
+
+This page collects a few ready-made system message builders that you can use
+to quickly customise the agent's behaviour. They live in the
+:mod:`pygent.prompt_library` module and work with
+:func:`~pygent.agent.set_system_message_builder`. The
+:mod:`pygent.agent_presets` module builds on top of these to offer ready-made
+agents with preset tool sets.
+
+```python
+from pygent import Agent, set_system_message_builder, PROMPT_BUILDERS
+
+# pick one of the predefined builders
+set_system_message_builder(PROMPT_BUILDERS["autonomous"])
+
+ag = Agent()
+ag.run_until_stop("echo hello")
+```
+
+Available builders:
+
+| Name | Description |
+| --- | --- |
+| ``autonomous`` | Runs without expecting user input and finishes by calling ``stop``. |
+| ``assistant`` | Encourages interactive behaviour asking for clarifications. |
+| ``reviewer`` | Focuses on reviewing code and suggesting improvements. |
+
+These builders are also used by the presets in
+:mod:`pygent.agent_presets` which include sensible tool selections.

--- a/examples/agent_presets.py
+++ b/examples/agent_presets.py
@@ -1,0 +1,7 @@
+"""Launch an agent using one of the predefined presets."""
+from pygent import AGENT_PRESETS
+
+ag = AGENT_PRESETS["autonomous"].create_agent()
+ag.run_until_stop("echo 'Preset demo'")
+ag.runtime.cleanup()
+

--- a/examples/prompt_library.py
+++ b/examples/prompt_library.py
@@ -1,0 +1,8 @@
+"""Demonstrate using the prompt library."""
+from pygent import Agent, PROMPT_BUILDERS, set_system_message_builder
+
+set_system_message_builder(PROMPT_BUILDERS["assistant"])
+
+ag = Agent()
+ag.step("echo 'Demo'")
+ag.runtime.cleanup()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ nav:
   - Tools: tools.md
   - Custom Models: custom-models.md
   - Custom System Message: custom-system-message.md
+  - Prompt Library: prompt-library.md
+  - Agent Presets: agent-presets.md
   - Multi-Agent Collaboration: crew-style.md
   - Architecture: architecture.md
   - Examples: examples.md

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -31,6 +31,8 @@ from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool, clear_tools, reset_tools, remove_tool  # noqa: E402,F401
 from .task_manager import TaskManager  # noqa: E402,F401
 from .task_tools import register_task_tools  # noqa: E402,F401
+from .prompt_library import PROMPT_BUILDERS  # noqa: E402,F401
+from .agent_presets import AGENT_PRESETS, AgentPreset  # noqa: E402,F401
 
 __all__ = [
     "Agent",
@@ -50,4 +52,7 @@ __all__ = [
     "remove_tool",
     "TaskManager",
     "register_task_tools",
+    "PROMPT_BUILDERS",
+    "AGENT_PRESETS",
+    "AgentPreset",
 ]

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -400,14 +400,31 @@ def run_interactive(
     disabled_tools: Optional[List[str]] = None,
     confirm_bash: Optional[bool] = None,
     banned_commands: Optional[List[str]] = None,
+    preset: Optional[str] = None,
 ) -> None:  # pragma: no cover
-    """Start an interactive session in the terminal."""
+    """Start an interactive session in the terminal.
+
+    Parameters
+    ----------
+    preset:
+        Name of a preset from :data:`pygent.agent_presets.AGENT_PRESETS` to use
+        when creating the agent.
+    """
     ws = pathlib.Path.cwd() / workspace_name if workspace_name else None
-    agent = Agent(
-        runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
-        disabled_tools=disabled_tools or [],
-        confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
-    )
+    if preset:
+        from .agent_presets import AGENT_PRESETS
+
+        agent = AGENT_PRESETS[preset].create_agent(
+            runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
+            disabled_tools=disabled_tools or [],
+            confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
+        )
+    else:
+        agent = Agent(
+            runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
+            disabled_tools=disabled_tools or [],
+            confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
+        )
     from .commands import COMMANDS
     mode = "Docker" if agent.runtime.use_docker else "local"
     console.print(

--- a/pygent/agent_presets.py
+++ b/pygent/agent_presets.py
@@ -1,0 +1,53 @@
+"""Predefined agent presets combining prompt builders and tool sets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from .persona import Persona
+from .agent import Agent, set_system_message_builder
+from .tools import reset_tools, remove_tool, TOOLS
+from .prompt_library import PROMPT_BUILDERS
+from .task_tools import register_task_tools
+
+
+@dataclass
+class AgentPreset:
+    """Factory for an :class:`~pygent.agent.Agent` with preset behaviour."""
+
+    builder: Callable[[Persona, Optional[List[str]]], str]
+    tools: Optional[List[str]] = None
+    include_task_tools: bool = False
+
+    def create_agent(self, **kwargs) -> Agent:
+        """Return an :class:`~pygent.agent.Agent` using this preset."""
+
+        set_system_message_builder(self.builder)
+        reset_tools()
+        if self.include_task_tools:
+            register_task_tools()
+        if self.tools is not None:
+            allowed = set(self.tools)
+            for name in list(TOOLS):
+                if name not in allowed:
+                    remove_tool(name)
+        return Agent(**kwargs)
+
+
+AGENT_PRESETS: dict[str, AgentPreset] = {
+    "autonomous": AgentPreset(
+        PROMPT_BUILDERS["autonomous"],
+        tools=["bash", "write_file", "stop", "read_image"],
+        include_task_tools=False,
+    ),
+    "assistant": AgentPreset(
+        PROMPT_BUILDERS["assistant"],
+        tools=["bash", "write_file", "ask_user", "stop", "read_image"],
+        include_task_tools=False,
+    ),
+    "reviewer": AgentPreset(
+        PROMPT_BUILDERS["reviewer"],
+        tools=["bash", "stop", "read_image"],
+        include_task_tools=False,
+    ),
+}

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -8,6 +8,7 @@ import os
 import typer
 
 from .config import load_config, run_py_config, load_snapshot
+from .agent_presets import AGENT_PRESETS
 
 
 app = typer.Typer(invoke_without_command=True, help="Pygent command line interface")
@@ -67,6 +68,12 @@ def main(
         help="command to ban (repeatable)",
         show_default=False,
     ),
+    preset: Optional[str] = typer.Option(
+        None,
+        "--preset",
+        help="start session using a predefined agent preset (autonomous, assistant, reviewer)",
+        show_default=False,
+    ),
 ) -> None:  # pragma: no cover - CLI wrapper
     """Start an interactive session when no subcommand is given."""
     load_config(config)
@@ -88,6 +95,7 @@ def main(
         "omit_tool": omit_tool or [],
         "confirm_bash": confirm_bash,
         "ban_cmd": ban_cmd or [],
+        "preset": preset,
     }
     if ctx.invoked_subcommand is None:
         from .agent import run_interactive
@@ -98,6 +106,7 @@ def main(
             disabled_tools=omit_tool or [],
             confirm_bash=confirm_bash,
             banned_commands=ban_cmd or [],
+            preset=preset,
         )
         raise typer.Exit()
 

--- a/pygent/prompt_library.py
+++ b/pygent/prompt_library.py
@@ -1,0 +1,32 @@
+"""Collection of ready-made system message builders for different agent styles."""
+from __future__ import annotations
+
+from typing import Optional, List, Callable
+
+from .persona import Persona
+from .agent import build_system_msg
+
+
+def autonomous_builder(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
+    """Prompt emphasising fully autonomous operation."""
+    base = build_system_msg(persona, disabled_tools)
+    return base + "\nAct autonomously without expecting user input. When the task is complete use the `stop` tool."
+
+
+def assistant_builder(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
+    """Prompt tuned for interactive assistant behaviour."""
+    base = build_system_msg(persona, disabled_tools)
+    return base + "\nEngage the user actively, asking for clarification whenever it might help."
+
+
+def reviewer_builder(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
+    """Prompt that focuses on reviewing and improving code."""
+    base = build_system_msg(persona, disabled_tools)
+    return base + "\nFocus on analysing existing code, pointing out bugs and suggesting improvements."
+
+
+PROMPT_BUILDERS: dict[str, Callable[[Persona, Optional[List[str]]], str]] = {
+    "autonomous": autonomous_builder,
+    "assistant": assistant_builder,
+    "reviewer": reviewer_builder,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.14"
+version = "0.2.15"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]


### PR DESCRIPTION
## Summary
- allow selecting built-in agent presets on the command line
- document preset option in CLI and agent preset docs
- support preset parameter in `run_interactive`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dc53337188321b633c766084b5bc3