### PR TITLE
Fix recursion when using preset autonomous

### DIFF
--- a/pygent/prompt_library.py
+++ b/pygent/prompt_library.py
@@ -4,24 +4,34 @@ from __future__ import annotations
 from typing import Optional, List, Callable
 
 from .persona import Persona
-from .agent import build_system_msg
+from . import agent
+
+
+def _base_system_msg(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
+    """Return the default system message ignoring any custom builder."""
+    current = agent._SYSTEM_MSG_BUILDER
+    agent._SYSTEM_MSG_BUILDER = None
+    try:
+        return agent.build_system_msg(persona, disabled_tools)
+    finally:
+        agent._SYSTEM_MSG_BUILDER = current
 
 
 def autonomous_builder(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
     """Prompt emphasising fully autonomous operation."""
-    base = build_system_msg(persona, disabled_tools)
+    base = _base_system_msg(persona, disabled_tools)
     return base + "\nAct autonomously without expecting user input. When the task is complete use the `stop` tool."
 
 
 def assistant_builder(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
     """Prompt tuned for interactive assistant behaviour."""
-    base = build_system_msg(persona, disabled_tools)
+    base = _base_system_msg(persona, disabled_tools)
     return base + "\nEngage the user actively, asking for clarification whenever it might help."
 
 
 def reviewer_builder(persona: Persona, disabled_tools: Optional[List[str]] = None) -> str:
     """Prompt that focuses on reviewing and improving code."""
-    base = build_system_msg(persona, disabled_tools)
+    base = _base_system_msg(persona, disabled_tools)
     return base + "\nFocus on analysing existing code, pointing out bugs and suggesting improvements."
 
 


### PR DESCRIPTION
## Summary
- fix recursion when creating presets by resetting system message builder before init
- update prompt library builders to ignore custom builder when generating base system message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd248aee8832190d67e72f07575a7