### PR TITLE
Add --cwd option to use current workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ can easily tell which agent is active.
 Pass `--confirm-bash` if you want to approve each bash command before it runs.
 Use `--ban-cmd CMD` to disallow specific commands entirely (repeat to ban multiple).
 Pass `--config path/to/pygent.toml` to load settings from a file.
+Use `--cwd` to run inside the current directory instead of a temporary workspace.
 
 Type messages normally; use `/exit` to end the session. Each command is executed
 in the container and the result shown in the terminal.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,7 @@ To start an interactive session, simply run `pygent` in your terminal. You can u
 * `--docker`/`--no-docker`: Forces command execution inside a Docker container or locally.
 * `--config <path>`: Loads configuration from a specific TOML file.
 * `--workspace <name>`: Defines a working directory for the session.
+* `--cwd`: Uses the current directory as the workspace instead of a temporary folder.
 * `--load <dir>`: Loads a snapshot of a previously saved environment, including the workspace, history, and environment variables.
 * `--confirm-bash`: Prompts for confirmation before executing any command with the `bash` tool. The command is shown in the terminal before asking for permission.
 * `--ban-cmd <command>`: Disables the execution of a specific command.

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -34,6 +34,11 @@ def main(
         "--workspace",
         help="name of workspace directory",
     ),
+    cwd: bool = typer.Option(
+        False,
+        "--cwd",
+        help="use the current directory as workspace",
+    ),
     pyconfig: Optional[str] = typer.Option(
         None,
         "--pyconfig",
@@ -85,6 +90,8 @@ def main(
         if "=" in item:
             key, val = item.split("=", 1)
             os.environ[key] = val
+    if cwd:
+        workspace = os.getcwd()
     if pyconfig:
         run_py_config(pyconfig)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.17"
+version = "0.2.18"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_cwd_workspace.py
+++ b/tests/test_cwd_workspace.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# minimal rich mocks
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: None
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.runtime import Runtime
+
+
+def test_cwd_workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rt = Runtime(use_docker=False, workspace='.')
+    rt.write_file('foo.txt', 'bar')
+    rt.cleanup()
+    assert (tmp_path / 'foo.txt').exists()


### PR DESCRIPTION
## Summary
- allow using the current directory as the agent workspace
- document the new `--cwd` CLI option
- mention the option in the README
- bump to v0.2.18
- test using `'.'` as workspace

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874eb295cf48321aee06a357dfda74f