### PR TITLE
Fix read_image MIME detection

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -12,7 +12,7 @@ Pygent comes with a set of essential tools ready to use:
     * **Parameters**: `path` (string), `content` (string).
 * **`stop`**: Stops the agent's autonomous execution loop. Useful for signaling the end of a task.
 * **`ask_user`**: Used to request a response or input from the user, continuing the conversation. When feasible, include an `options` list to present a short menu.
-* **`read_image`**: Returns a data URL for an image in the workspace, useful for vision models.
+* **`read_image`**: Returns a data URL for an image in the workspace, useful for vision models. The MIME type is detected from the file contents when the extension is unknown.
 
 ## Task Tools
 

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from typing import Any, Callable, Dict, List, Optional
 import mimetypes
+import imghdr
 from pathlib import Path
 from copy import deepcopy
 
@@ -235,8 +236,12 @@ def _read_image(rt: Runtime, path: str) -> str:
         return data
     mime, _ = mimetypes.guess_type(path)
     if not mime or not mime.startswith("image/"):
-        ext = Path(path).suffix.lstrip(".") or "png"
-        mime = f"image/{ext}"
+        guessed = imghdr.what(rt.base_dir / path)
+        if guessed:
+            mime = f"image/{guessed}"
+        else:
+            ext = Path(path).suffix.lstrip(".") or "png"
+            mime = f"image/{ext}"
     return f"data:{mime};base64,{data}"
 
 # snapshot of the default built-in registry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.18"
+version = "0.2.19"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -129,6 +129,14 @@ def test_read_image_data_url(tmp_path):
     assert result.startswith("data:image/png;base64,")
 
 
+def test_read_image_detects_mime_from_contents(tmp_path):
+    rt = Runtime(use_docker=False, workspace=tmp_path)
+    img = tmp_path / "img"
+    img.write_bytes(b"\x89PNG\r\n")
+    result = tools._read_image(rt, path="img")
+    assert result.startswith("data:image/png;base64,")
+
+
 def test_workflow_block_respects_ask_user():
     reset_tools()
     ag = Agent()


### PR DESCRIPTION
## Summary
- detect image MIME type from file contents
- document improved behavior
- test detection fallback for images without extension
- bump package version to 0.2.19

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68754a3fb6b48321a7b2eb98beb87fc0