### PR TITLE
Add automatic history trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Behaviour can be adjusted via environment variables (see `docs/configuration.md`
 * `PYGENT_IMAGE` &ndash; Docker image to create the container (default `python:3.12-slim`).
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
 * `PYGENT_MAX_TASKS` &ndash; maximum number of concurrent delegated tasks (default `3`).
+* `PYGENT_MAX_HISTORY` &ndash; maximum number of messages kept in memory before old ones are discarded (default `50`).
 
 Settings can also be read from a `pygent.toml` file. See
 [examples/sample_config.toml](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ exported in your shell or set via a `.env` file before running the CLI.
 | `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
 | `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
 | `PYGENT_HISTORY_FILE` | Path to a JSON file where the conversation history is saved. | – |
+| `PYGENT_MAX_HISTORY` | Maximum number of messages kept in memory before older ones are trimmed. | `50` |
 | `PYGENT_WORKSPACE` | Directory used to persist the workspace between sessions. | – |
 | `PYGENT_SNAPSHOT` | Load environment and history from the given directory on startup. | – |
 | `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |

--- a/tests/test_context_error.py
+++ b/tests/test_context_error.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import types
+import pytest
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pygent import Agent, openai_compat
+from pygent.errors import APIError
+from pygent.runtime import Runtime
+
+class FailingModel:
+    def __init__(self):
+        self.calls = []
+    def chat(self, messages, model, tools):
+        self.calls.append(len(messages))
+        if len(messages) > 3:
+            raise APIError('maximum context length')
+        return openai_compat.Message(role='assistant', content='ok')
+
+def test_trim_history_on_context_error(monkeypatch):
+    monkeypatch.setenv('PYGENT_MAX_HISTORY', '50')
+    model = FailingModel()
+    ag = Agent(runtime=Runtime(use_docker=False), model=model)
+    ag.step('hello')
+    ag.step('again')
+    assert model.calls == [2, 4, 3]
+    assert len(ag.history) <= 3


### PR DESCRIPTION
## Summary
- add `PYGENT_MAX_HISTORY` env var
- trim history when the context grows too much
- retry model call when API errors mention context length
- document new variable
- test that long histories are trimmed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e5482cec8321b31adaea40cf8b4e