### PR TITLE
Abstract CLI session interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Optional web interface via `pygent ui` (also available as `pygent-ui`).
 * Register your own tools and customise the system prompt.
 * Extend the CLI with custom commands.
+* Build custom interactive sessions by subclassing the `Session` API.
 * Execute a `config.py` script on startup for advanced configuration.
 * Set environment variables from the command line.
 * Each session begins with a short plan that you can approve before execution.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,3 +29,7 @@ Within the interactive session, you can use the following commands that start wi
 * `/banned [list|add|remove <name>]`: Lists, adds, or removes commands from the list of banned commands in the `runtime`.
 * `/confirm-bash [on|off]`: Enables or disables confirmation before running `bash` commands during the session.
 * `/exit`: Ends the interactive session.
+
+## Custom Sessions
+
+The interactive loop is implemented by the `Session` class. The default `CliSession` uses `rich` and `questionary` to handle terminal input and output. Subclass `Session` to integrate Pygent into other environments such as GUIs or notebooks and call `run()` on your custom session.

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -26,6 +26,7 @@ from .agent import (
     run_interactive,
     set_system_message_builder,
 )
+from .session import Session, CliSession
 from .models import Model, OpenAIModel, set_custom_model  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool, clear_tools, reset_tools, remove_tool  # noqa: E402,F401
@@ -43,6 +44,8 @@ __all__ = [
     "OpenAIModel",
     "set_custom_model",
     "set_system_message_builder",
+    "Session",
+    "CliSession",
     "PygentError",
     "APIError",
     "register_tool",

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -94,6 +94,7 @@ def build_system_msg(persona: Persona, disabled_tools: Optional[List[str]] = Non
     # 3) Workflow block
     has_ask = any(s["function"]["name"] == "ask_user" for s in schemas)
     has_stop = any(s["function"]["name"] == "stop" for s in schemas)
+    has_image = any(s["function"]["name"] == "read_image" for s in schemas)
 
     first_line = "First, present a concise plan (≤ 5 lines)"
     if has_ask:
@@ -122,6 +123,10 @@ def build_system_msg(persona: Persona, disabled_tools: Optional[List[str]] = Non
         workflow_parts.append("When the task is fully complete, use the `stop` tool.")
     workflow_block = " ".join(workflow_parts)
 
+    if has_image:
+        workflow_block += (
+            " If you need to read an image, use the `read_image` tool and provide a path."
+        )
     # 4) Optional bash note
     bash_note = (
         "You can execute shell commands in an isolated environment via the `bash` tool, "

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -33,6 +33,7 @@ except Exception:  # pragma: no cover - used in tests without questionary
 
 from .runtime import Runtime
 from . import tools, models, openai_compat
+from .session import CliSession
 from .models import Model, OpenAIModel
 from .persona import Persona
 
@@ -429,69 +430,5 @@ def run_interactive(
             disabled_tools=disabled_tools or [],
             confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
         )
-    from .commands import COMMANDS
-    mode = "Docker" if agent.runtime.use_docker else "local"
-    console.print(
-        f"[bold green]{agent.persona.name} ({mode})[/] started. (Type /exit to quit)"
-    )
-    console.print("Type /help for a list of available commands.")
-    try:
-        next_msg: Optional[str] = None
-        while True:
-            if next_msg is None:
-                user_msg = console.input("[bold steel_blue]>>> [/]")
-            else:
-                console.print(f"[bold steel_blue]>>> [/]{next_msg}", highlight=False)
-                user_msg = next_msg
-                next_msg = None
-            if agent._log_fp:
-                try:
-                    agent._log_fp.write(f"user> {user_msg}\n")
-                    agent._log_fp.flush()
-                except Exception:
-                    pass
-            if not user_msg.strip():
-                continue
-            parts = user_msg.split(maxsplit=1)
-            cmd = parts[0]
-            args = parts[1] if len(parts) == 2 else ""
-            if cmd in {"/exit", "quit", "q"}:
-                break
-            if cmd in COMMANDS:
-                result = COMMANDS[cmd](agent, args)
-                if isinstance(result, Agent):
-                    agent = result
-                continue
-            last = agent.run_until_stop(user_msg)
-            if last and last.tool_calls:
-                for call in last.tool_calls:
-                    if call.function.name == "ask_user":
-                        args = json.loads(call.function.arguments or "{}")
-                        options = args.get("options")
-                        if options:
-                            prompt = args.get("prompt", "Choose:")
-                            if questionary:
-                                next_msg = questionary.select(prompt, choices=options).ask()
-                            else:  # pragma: no cover - simple fallback for tests
-                                opts = "/".join(options)
-                                next_msg = input(f"{prompt} ({opts}): ")
-                        break
-    except Exception as exc:  # pragma: no cover - interactive only
-        from .commands import cmd_save
-        dest = pathlib.Path.cwd() / f"crash_{uuid.uuid4().hex[:8]}"
-        cmd_save(agent, str(dest))
-        console.print(
-            Panel(
-                f"An unexpected error occurred: [bold red]{exc}[/]\n"
-                f"Your workspace has been saved to [cyan]{dest}[/].\n"
-                f"You can restore it using: [bold yellow]pygent --load {dest}[/]",
-                title="[bold red]Critical Error[/]",
-                border_style="red",
-                box=box.DOUBLE if box else None,
-            )
-        )
-        # raise # Optionally re-raise the exception if needed for debugging or higher-level handling
-    finally:
-        console.print("[dim]Closing session...[/]")
-        agent.close()
-        agent.runtime.cleanup()
+    session = CliSession(agent)
+    session.run()

--- a/pygent/session.py
+++ b/pygent/session.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from typing import List, Optional, TYPE_CHECKING
+import pathlib
+import uuid
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .agent import Agent
+from rich.console import Console
+try:  # optional rich features
+    from rich import __version__ as _rich_version  # noqa: F401
+    from rich.panel import Panel
+    from rich import box
+except Exception:  # pragma: no cover - tests may stub out rich
+    import rich as _rich
+    if not hasattr(_rich, "__version__"):
+        _rich.__version__ = "0"
+    if not hasattr(_rich, "__file__"):
+        _rich.__file__ = "rich-not-installed"
+    Panel = None  # type: ignore
+    box = None
+try:  # optional dependency
+    import questionary  # type: ignore
+except Exception:  # pragma: no cover - used in tests without questionary
+    questionary = None
+
+
+class Session(ABC):
+    """Abstract interactive session."""
+
+    def __init__(self, agent: Agent) -> None:
+        self.agent = agent
+        self.console = Console()
+
+    @abstractmethod
+    def get_input(self, prompt: str) -> str:
+        """Return user input for ``prompt``."""
+
+    def ask(self, prompt: str, options: List[str]) -> str:
+        """Ask the user to choose from ``options``."""
+        return self.get_input(f"{prompt} ({'/'.join(options)}): ")
+
+    def start_message(self) -> None:
+        mode = "Docker" if self.agent.runtime.use_docker else "local"
+        self.console.print(
+            f"[bold green]{self.agent.persona.name} ({mode})[/] started. (Type /exit to quit)"
+        )
+        self.console.print("Type /help for a list of available commands.")
+
+    def end_session(self) -> None:
+        self.console.print("[dim]Closing session...[/]")
+        self.agent.close()
+        self.agent.runtime.cleanup()
+
+    def run(self) -> None:
+        """Run the interactive loop."""
+        from .commands import COMMANDS
+
+        self.start_message()
+        next_msg: Optional[str] = None
+        try:
+            while True:
+                if next_msg is None:
+                    user_msg = self.get_input("[bold steel_blue]>>> [/]")
+                else:
+                    self.console.print(f"[bold steel_blue]>>> [/]{next_msg}", highlight=False)
+                    user_msg = next_msg
+                    next_msg = None
+                if self.agent._log_fp:
+                    try:
+                        self.agent._log_fp.write(f"user> {user_msg}\n")
+                        self.agent._log_fp.flush()
+                    except Exception:
+                        pass
+                if not user_msg.strip():
+                    continue
+                parts = user_msg.split(maxsplit=1)
+                cmd = parts[0]
+                args = parts[1] if len(parts) == 2 else ""
+                if cmd in {"/exit", "quit", "q"}:
+                    break
+                if cmd in COMMANDS:
+                    result = COMMANDS[cmd](self.agent, args)
+                    if isinstance(result, Agent):
+                        self.agent = result
+                    continue
+                last = self.agent.run_until_stop(user_msg)
+                if last and last.tool_calls:
+                    for call in last.tool_calls:
+                        if call.function.name == "ask_user":
+                            args = json.loads(call.function.arguments or "{}")
+                            options = args.get("options")
+                            if options:
+                                prompt = args.get("prompt", "Choose:")
+                                next_msg = self.ask(prompt, options)
+                            break
+        except Exception as exc:  # pragma: no cover - interactive only
+            from .commands import cmd_save
+            dest = pathlib.Path.cwd() / f"crash_{uuid.uuid4().hex[:8]}"
+            cmd_save(self.agent, str(dest))
+            if Panel:
+                self.console.print(
+                    Panel(
+                        f"An unexpected error occurred: [bold red]{exc}[/]\n"
+                        f"Your workspace has been saved to [cyan]{dest}[/].\n"
+                        f"You can restore it using: [bold yellow]pygent --load {dest}[/]",
+                        title="[bold red]Critical Error[/]",
+                        border_style="red",
+                        box=box.DOUBLE if box else None,
+                    )
+                )
+            else:  # pragma: no cover - fallback without rich
+                print(
+                    f"An unexpected error occurred: {exc}\nWorkspace saved to {dest}\n"
+                    f"Restore with: pygent --load {dest}"
+                )
+        finally:
+            self.end_session()
+
+
+class CliSession(Session):
+    """Interactive CLI session using ``rich`` and ``questionary`` when available."""
+
+    def get_input(self, prompt: str) -> str:  # pragma: no cover - interactive
+        return self.console.input(prompt)
+
+    def ask(self, prompt: str, options: List[str]) -> str:  # pragma: no cover - interactive
+        if questionary:
+            return questionary.select(prompt, choices=options).ask()
+        return super().ask(prompt, options)
+

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -220,7 +220,7 @@ def _download_file(rt: Runtime, path: str, binary: bool = False) -> str:
 
 @tool(
     name="read_image",
-    description="Return a data URL for an image in the workspace.",
+    description="If you use this tool, you will read the image provided.",
     parameters={
         "type": "object",
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.2.19"
+version = "0.2.20"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,77 @@
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None, 'input': lambda self, prompt='': ''})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from pygent.session import Session
+from pygent import openai_compat
+
+class DummyAgent:
+    def __init__(self):
+        self.persona = types.SimpleNamespace(name='bot')
+        self.runtime = types.SimpleNamespace(use_docker=False, cleanup=lambda: None)
+        self._log_fp = None
+        self.closed = False
+        self.calls = []
+    def run_until_stop(self, msg):
+        self.calls.append(msg)
+        if msg == 'start':
+            tc = openai_compat.ToolCall(
+                id='1',
+                type='function',
+                function=openai_compat.ToolCallFunction(
+                    name='ask_user',
+                    arguments='{"prompt": "Pick", "options": ["a", "b"]}'
+                )
+            )
+            return openai_compat.Message(role='assistant', content=None, tool_calls=[tc])
+        return None
+    def close(self):
+        self.closed = True
+
+
+def test_session_ask_uses_get_input():
+    agent = DummyAgent()
+    prompts = []
+    class MySession(Session):
+        def get_input(self, prompt: str) -> str:
+            prompts.append(prompt)
+            return 'x'
+    session = MySession(agent)
+    out = session.ask('Choose', ['a', 'b'])
+    assert out == 'x'
+    assert prompts == ['Choose (a/b): ']
+
+
+def test_session_run_handles_ask_user():
+    agent = DummyAgent()
+    closed = []
+    agent.runtime.cleanup = lambda: closed.append('cleanup')
+    agent.close = lambda: closed.append('close')
+
+    inputs = ['start', '/exit']
+    class MySession(Session):
+        def get_input(self, prompt: str) -> str:
+            return inputs.pop(0)
+        def ask(self, prompt: str, options):
+            return 'a'
+    session = MySession(agent)
+    session.run()
+    assert agent.calls == ['start', 'a']
+    assert 'close' in closed and 'cleanup' in closed


### PR DESCRIPTION
## Summary
- add `Session` and `CliSession` classes to expose a pluggable session interface
- refactor `run_interactive` to use the new `CliSession`
- export session classes in the package API
- document custom sessions and add unit tests
- bump package version to `0.2.20`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e5f12c84832181d9f2452c6f351e