### PR TITLE
Enable multimodal image handling

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ Within the interactive session, you can use the following commands that start wi
 * `/help [command]`: Shows a detailed list of available commands, including their descriptions and usage patterns. If a specific command is provided (e.g., `/help /cp`), it displays detailed help for that command.
 * `/cmd <command>`: Executes a shell command directly in the `runtime` environment (local or Docker). Example: `/cmd ls -la`
 * `/cp <source> [destination]`: Copies a file from your local system to the agent's workspace. Example: `/cp my_script.py agent_scripts/`
+* `/img <path>`: Sends an image file to the assistant as a message so vision models can process it.
 * `/new`: Restarts the conversation, clearing the history but keeping the current `runtime` (and workspace, if persistent).
 * `/save <dir>`: Saves the current state, including the workspace, conversation history, and environment variables, to a directory for later use.
 * `/tools [list|enable|disable <name>]`: Lists available tools or enables/disables a specific tool during the session.

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -234,6 +234,29 @@ class Agent:
             with self.history_file.open("w", encoding="utf-8") as fh:
                 json.dump([self._message_dict(m) for m in self.history], fh)
 
+    def _format_content(self, content: Any) -> str:
+        """Return a Markdown-friendly string for ``content``."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    typ = part.get("type")
+                    if typ == "text":
+                        parts.append(part.get("text", ""))
+                    elif typ == "image_url":
+                        url = part.get("image_url", {}).get("url", "")
+                        parts.append(f"![image]({url})")
+                    else:
+                        parts.append(str(part))
+                else:
+                    parts.append(str(part))
+            return "\n\n".join(parts)
+        return str(content)
+
     def append_history(self, msg: Any) -> None:
         self.history.append(msg)
         self._save_history()
@@ -337,7 +360,7 @@ class Agent:
                         )
                     )
         else:
-            markdown_response = Markdown(assistant_msg.content or "") # Ensure content is not None
+            markdown_response = Markdown(self._format_content(assistant_msg.content))
             console.print(
                 Panel(
                     markdown_response,

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -239,6 +239,8 @@ class Agent:
         if content is None:
             return ""
         if isinstance(content, str):
+            if content.startswith("data:image"):
+                return f"![image]({content})"
             return content
         if isinstance(content, list):
             parts = []

--- a/pygent/openai_compat.py
+++ b/pygent/openai_compat.py
@@ -28,7 +28,7 @@ class ToolCall:
 @dataclass
 class Message:
     role: str
-    content: Optional[str] = None
+    content: Any = None
     tool_calls: Optional[List[ToolCall]] = None
 
 

--- a/pygent/session.py
+++ b/pygent/session.py
@@ -83,7 +83,7 @@ class Session(ABC):
                     break
                 if cmd in COMMANDS:
                     result = COMMANDS[cmd](self.agent, args)
-                    if isinstance(result, Agent):
+                    if isinstance(result, type(self.agent)):
                         self.agent = result
                     continue
                 last = self.agent.run_until_stop(user_msg)

--- a/pygent/ui.py
+++ b/pygent/ui.py
@@ -1,6 +1,6 @@
 """Simple Gradio-based chat interface."""
 
-from .agent import Agent
+from .agent import Agent, _format_content
 from .runtime import Runtime
 from .tools import execute_tool, TOOL_SCHEMAS
 from . import openai_compat
@@ -25,7 +25,7 @@ def run_gui(use_docker: Optional[bool] = None) -> None:
         raw = agent.model.chat(agent.history, agent.model_name, TOOL_SCHEMAS)
         assistant_msg = openai_compat.parse_message(raw)
         agent.append_history(assistant_msg)
-        reply = assistant_msg.content or ""
+        reply = _format_content(assistant_msg.content)
         if assistant_msg.tool_calls:
             for call in assistant_msg.tool_calls:
                 output = execute_tool(call, agent.runtime)

--- a/pygent/ui.py
+++ b/pygent/ui.py
@@ -1,6 +1,6 @@
 """Simple Gradio-based chat interface."""
 
-from .agent import Agent, _format_content
+from .agent import Agent
 from .runtime import Runtime
 from .tools import execute_tool, TOOL_SCHEMAS
 from . import openai_compat
@@ -25,7 +25,7 @@ def run_gui(use_docker: Optional[bool] = None) -> None:
         raw = agent.model.chat(agent.history, agent.model_name, TOOL_SCHEMAS)
         assistant_msg = openai_compat.parse_message(raw)
         agent.append_history(assistant_msg)
-        reply = _format_content(assistant_msg.content)
+        reply = agent._format_content(assistant_msg.content)
         if assistant_msg.tool_calls:
             for call in assistant_msg.tool_calls:
                 output = execute_tool(call, agent.runtime)

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -23,6 +23,7 @@ from dataclasses import asdict
 from pygent import openai_compat
 from pygent.models import OpenAIModel
 import pygent.models
+from pygent.agent import Agent
 
 
 def test_parse_message_with_image_list():
@@ -60,3 +61,14 @@ def test_openai_model_serializes_image():
     sent = calls[0]['messages'][0]['content']
     assert isinstance(sent, list)
     assert sent[0]['image_url']['url'].startswith('data:image')
+
+
+def test_format_content_with_image():
+    ag = Agent()
+    items = [
+        {'type': 'text', 'text': 'see'},
+        {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,AAA='}},
+    ]
+    rendered = ag._format_content(items)
+    assert 'see' in rendered
+    assert 'data:image' in rendered

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,0 +1,62 @@
+import sys
+import types
+
+sys.modules['openai'] = types.ModuleType('openai')
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+from dataclasses import asdict
+from pygent import openai_compat
+from pygent.models import OpenAIModel
+import pygent.models
+
+
+def test_parse_message_with_image_list():
+    raw = {
+        'role': 'user',
+        'content': [
+            {'type': 'text', 'text': 'look'},
+            {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,AAA='}},
+        ],
+    }
+    msg = openai_compat.parse_message(raw)
+    assert isinstance(msg.content, list)
+    dumped = asdict(msg)
+    assert dumped['content'][1]['image_url']['url'].startswith('data:image')
+
+
+def test_openai_model_serializes_image():
+    calls = []
+    openai = sys.modules['openai']
+    openai.chat = types.SimpleNamespace()
+    pygent.models.openai = openai
+
+    def create(**kwargs):
+        calls.append(kwargs)
+        ch = openai_compat.Choice(
+            message=openai_compat.Message(role='assistant', content='ok')
+        )
+        return openai_compat.ChatCompletion(choices=[ch])
+
+    openai.chat.completions = types.SimpleNamespace(create=create)
+
+    model = OpenAIModel()
+    msg = openai_compat.Message(role='tool', content='data:image/png;base64,AAA=')
+    model.chat([msg], 'gpt', None)
+    sent = calls[0]['messages'][0]['content']
+    assert isinstance(sent, list)
+    assert sent[0]['image_url']['url'].startswith('data:image')


### PR DESCRIPTION
## Summary
- allow Message content to hold any type
- convert data URLs to OpenAI image objects when calling the API
- cover multimodal behaviour in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f5f32f648321b60c9b7117f56106