### PR TITLE
Add FastAPI server for task management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Persist the workspace across sessions by setting `PYGENT_WORKSPACE`.
 * Provides a small Python API for use in other projects.
 * Optional web interface via `pygent ui` (also available as `pygent-ui`).
+* Optional FastAPI server to manage tasks over HTTP.
 * Register your own tools and customise the system prompt.
 * Extend the CLI with custom commands.
 * Build custom interactive sessions by subclassing the `Session` API.
@@ -27,10 +28,10 @@ The recommended way to install Pygent is using pip:
 pip install pygent
 ```
 
-To include optional features like Docker support or the web UI, you can specify extras:
+To include optional features like Docker support, the web UI, or the FastAPI server, you can specify extras:
 
 ```bash
-pip install pygent[docker,ui]
+pip install pygent[docker,ui,server]
 ```
 
 Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
@@ -43,7 +44,7 @@ pip install -e .
 ```
 
 Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
-To run commands in Docker containers, Docker must be installed separately. If installing from source, you can include Docker support with `pip install -e .[docker]`.
+To run commands in Docker containers, Docker must be installed separately. If installing from source, you can include Docker support with `pip install -e .[docker,ui,server]`.
 
 ## Configuration
 
@@ -87,6 +88,7 @@ in the container and the result shown in the terminal.
 Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
 For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
+To expose the API over HTTP run `uvicorn pygent.fastapi_app:create_app` (requires `pygent[server]`).
 Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 Use `/save DIR` to snapshot the current environment for later use.
 Use `/tools` to enable or disable tools during the session.

--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -1,0 +1,25 @@
+# FastAPI Server
+
+Pygent can expose the `TaskManager` over HTTP using FastAPI. This optional server lets you create and monitor tasks remotely, mirroring the CLI workflow.
+
+Install the server dependencies with the `server` extra:
+
+```bash
+pip install pygent[server]
+```
+
+Start the server with `uvicorn`:
+
+```bash
+uvicorn pygent.fastapi_app:create_app
+```
+
+The API provides the following endpoints:
+
+* `POST /tasks` – start a new task. Payload fields match the arguments of `TaskManager.start_task`.
+* `GET /tasks` – list task IDs and their status.
+* `GET /tasks/{task_id}` – retrieve the status of a task.
+* `POST /tasks/{task_id}/message` – send a message to a finished task and get the reply.
+* `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
+
+Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,10 +13,10 @@ The recommended way to install Pygent is using pip:
 pip install pygent
 ```
 
-To include optional features like Docker support or the web UI, you can specify extras:
+To include optional features like Docker support, the web UI, or the FastAPI server, you can specify extras:
 
 ```bash
-pip install pygent[docker,ui]
+pip install pygent[docker,ui,server]
 ```
 
 Python 3.9 or newer is required. If Docker is not installed on your system, you should omit the `[docker]` extra; commands that would use Docker will then run on the host system instead. Docker itself needs to be installed separately if you wish to use containerized execution.
@@ -26,7 +26,7 @@ For developers or those wanting the latest unreleased features, Pygent can also 
 ```bash
 pip install -e .
 ```
-You can include extras like `[docker,ui]` when installing from source as well (e.g., `pip install -e .[docker,ui]`).
+You can include extras like `[docker,ui,server]` when installing from source as well (e.g., `pip install -e .[docker,ui,server]`).
 
 ## Interactive session
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Agent Presets: agent-presets.md
   - Multi-Agent Collaboration: crew-style.md
   - Architecture: architecture.md
+  - FastAPI Server: fastapi-server.md
   - Examples: examples.md
   - API Reference: api-reference.md
 theme:

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -34,6 +34,10 @@ from .task_manager import TaskManager  # noqa: E402,F401
 from .task_tools import register_task_tools  # noqa: E402,F401
 from .prompt_library import PROMPT_BUILDERS  # noqa: E402,F401
 from .agent_presets import AGENT_PRESETS, AgentPreset  # noqa: E402,F401
+try:  # optional dependency
+    from .fastapi_app import create_app  # noqa: E402,F401
+except Exception:  # pragma: no cover - optional
+    create_app = None  # type: ignore
 
 __all__ = [
     "Agent",
@@ -58,4 +62,5 @@ __all__ = [
     "PROMPT_BUILDERS",
     "AGENT_PRESETS",
     "AgentPreset",
+    "create_app",
 ]

--- a/pygent/fastapi_app.py
+++ b/pygent/fastapi_app.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""FastAPI server exposing the :class:`TaskManager` over HTTP."""
+
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .task_manager import TaskManager
+from .runtime import Runtime
+
+
+class _NewTask(BaseModel):
+    prompt: str
+    files: Optional[List[str]] = None
+    persona: Optional[str] = None
+    step_timeout: Optional[float] = None
+    task_timeout: Optional[float] = None
+
+
+class _UserMessage(BaseModel):
+    message: str
+    step_timeout: Optional[float] = None
+    max_time: Optional[float] = None
+
+
+def create_app() -> FastAPI:
+    """Return a ``FastAPI`` application wrapping :class:`TaskManager`."""
+
+    manager = TaskManager()
+    runtime = Runtime()
+
+    app = FastAPI()
+    app.state.manager = manager
+    app.state.runtime = runtime
+
+    @app.post("/tasks")
+    def start_task(req: _NewTask):
+        tid = manager.start_task(
+            req.prompt,
+            runtime,
+            files=req.files,
+            persona=req.persona,
+            step_timeout=req.step_timeout,
+            task_timeout=req.task_timeout,
+        )
+        return {"task_id": tid}
+
+    @app.get("/tasks")
+    def list_tasks():
+        return [
+            {"id": tid, "status": task.status}
+            for tid, task in manager.tasks.items()
+        ]
+
+    @app.get("/tasks/{task_id}")
+    def task_status(task_id: str):
+        if task_id not in manager.tasks:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return {"id": task_id, "status": manager.status(task_id)}
+
+    @app.post("/tasks/{task_id}/message")
+    def message_task(task_id: str, req: _UserMessage):
+        task = manager.tasks.get(task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+        if task.thread.is_alive():
+            raise HTTPException(status_code=409, detail="Task is running")
+        reply = task.agent.run_until_stop(
+            req.message,
+            step_timeout=req.step_timeout,
+            max_time=req.max_time,
+        )
+        content = reply.content if reply else ""
+        return {"response": content}
+
+    @app.get("/tasks/{task_id}/history")
+    def task_history(task_id: str):
+        task = manager.tasks.get(task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return task.agent.history
+
+    return app
+
+
+def main() -> None:  # pragma: no cover - optional CLI
+    import uvicorn
+
+    uvicorn.run(create_app())
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ test = ["pytest"]
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]"]
 docker = ["docker>=7.0.0"]
 ui = ["gradio"]
+server = ["fastapi", "uvicorn"]
 
 [project.urls]
 Documentation = "https://pygent-ai.com"

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -2,8 +2,12 @@ import os
 import sys
 import types
 
-sys.modules.setdefault('openai', types.ModuleType('openai'))
-sys.modules.setdefault('docker', types.ModuleType('docker'))
+import pytest
+
+pytest.importorskip("fastapi")
+
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+sys.modules.setdefault("docker", types.ModuleType("docker"))
 
 # mocks for rich
 rich_mod = types.ModuleType('rich')

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('docker', types.ModuleType('docker'))
+
+# mocks for rich
+rich_mod = types.ModuleType('rich')
+console_mod = types.ModuleType('console')
+panel_mod = types.ModuleType('panel')
+markdown_mod = types.ModuleType('markdown')
+syntax_mod = types.ModuleType('syntax')
+console_mod.Console = lambda *a, **k: type('C', (), {'print': lambda *a, **k: None})()
+panel_mod.Panel = lambda *a, **k: None
+markdown_mod.Markdown = lambda *a, **k: None
+syntax_mod.Syntax = lambda *a, **k: None
+sys.modules.setdefault('rich', rich_mod)
+sys.modules.setdefault('rich.console', console_mod)
+sys.modules.setdefault('rich.panel', panel_mod)
+sys.modules.setdefault('rich.markdown', markdown_mod)
+sys.modules.setdefault('rich.syntax', syntax_mod)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi.testclient import TestClient
+from pygent.fastapi_app import create_app
+from pygent import openai_compat
+from pygent.models import set_custom_model
+
+
+class DummyModel:
+    def chat(self, messages, model, tools):
+        return openai_compat.Message(role='assistant', content='ok')
+
+
+def test_api_lifecycle():
+    set_custom_model(DummyModel())
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.post('/tasks', json={'prompt': 'run'})
+    tid = resp.json()['task_id']
+
+    # wait for task to finish
+    app.state.manager.tasks[tid].thread.join()
+
+    status = client.get(f'/tasks/{tid}').json()['status']
+    assert status == 'finished'
+
+    lst = client.get('/tasks').json()
+    assert any(t['id'] == tid for t in lst)
+
+    resp = client.post(f'/tasks/{tid}/message', json={'message': 'hello'})
+    assert resp.json()['response'] == 'ok'
+
+    set_custom_model(None)
+


### PR DESCRIPTION
## Summary
- add optional `server` extras with `fastapi` and `uvicorn`
- implement `fastapi_app` exposing TaskManager over HTTP
- export `create_app` when FastAPI is available
- test FastAPI app with dummy model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d741f20f88321a4edc2fa291f12e8