### PR TITLE
Add web interface for FastAPI server

### DIFF
--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -14,6 +14,13 @@ Start the server with `uvicorn`:
 uvicorn pygent.fastapi_app:create_app
 ```
 
+Alternatively run the `pygent-web` script to include a small web interface under
+`/ui`:
+
+```bash
+pygent-web
+```
+
 The API provides the following endpoints:
 
 * `POST /tasks` – start a new task. Payload fields match the arguments of `TaskManager.start_task`.
@@ -23,3 +30,6 @@ The API provides the following endpoints:
 * `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
 
 Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.
+
+When started with `pygent-web`, open `http://localhost:8000/ui` in your browser
+to interact with the API without writing any code.

--- a/pygent/static/index.html
+++ b/pygent/static/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Pygent API Web UI</title>
+<style>
+body { font-family: sans-serif; margin: 2em; }
+textarea { width: 100%; }
+pre { background: #f5f5f5; padding: 1em; }
+</style>
+</head>
+<body>
+<h1>Pygent API Web UI</h1>
+<form id="task-form">
+<p><label>Prompt:<br><textarea id="prompt" rows="4"></textarea></label></p>
+<p><button type="submit">Start Task</button></p>
+</form>
+<div id="task" style="display:none;">
+<p>Task ID: <span id="task-id"></span></p>
+<p>Status: <span id="task-status"></span></p>
+<form id="message-form" style="margin-top:1em;">
+<label>Message: <input id="message" type="text" /></label>
+<button type="submit">Send</button>
+</form>
+<h2>History</h2>
+<pre id="history"></pre>
+</div>
+<script>
+let tid = null;
+const taskForm = document.getElementById('task-form');
+const messageForm = document.getElementById('message-form');
+const statusEl = document.getElementById('task-status');
+const historyEl = document.getElementById('history');
+
+taskForm.addEventListener('submit', async (ev) => {
+  ev.preventDefault();
+  const prompt = document.getElementById('prompt').value;
+  const resp = await fetch('/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({prompt})
+  });
+  const data = await resp.json();
+  tid = data.task_id;
+  document.getElementById('task-id').textContent = tid;
+  document.getElementById('task').style.display = 'block';
+  pollStatus();
+});
+
+messageForm.addEventListener('submit', async (ev) => {
+  ev.preventDefault();
+  const msg = document.getElementById('message').value;
+  const resp = await fetch(`/tasks/${tid}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({message: msg})
+  });
+  const data = await resp.json();
+  historyEl.textContent += `\nUSER: ${msg}\nASSISTANT: ${data.response}\n`;
+});
+
+async function pollStatus() {
+  if (!tid) return;
+  const resp = await fetch(`/tasks/${tid}`);
+  const data = await resp.json();
+  statusEl.textContent = data.status;
+  if (data.status === 'finished') {
+    const hresp = await fetch(`/tasks/${tid}/history`);
+    const hist = await hresp.json();
+    historyEl.textContent = JSON.stringify(hist, null, 2);
+  } else {
+    setTimeout(pollStatus, 1000);
+  }
+}
+</script>
+</body>
+</html>

--- a/pygent/web_app.py
+++ b/pygent/web_app.py
@@ -1,0 +1,11 @@
+"""Run the FastAPI server with the built-in web interface."""
+
+from .fastapi_app import create_app
+
+
+app = create_app(include_ui=True)
+
+
+def main() -> None:  # pragma: no cover - optional CLI
+    import uvicorn
+    uvicorn.run(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ Repository = "https://github.com/marianochaves/pygent"
 [project.scripts]
 pygent = "pygent.cli:main"
 pygent-ui = "pygent.ui:main"
+pygent-web = "pygent.web_app:main"
 
 
 [tool.setuptools.package-data]

--- a/tests/test_fastapi_web.py
+++ b/tests/test_fastapi_web.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+sys.modules.setdefault("openai", types.ModuleType("openai"))
+sys.modules.setdefault("docker", types.ModuleType("docker"))
+
+from fastapi.testclient import TestClient
+from pygent.fastapi_app import create_app
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_web_ui_served():
+    app = create_app(include_ui=True)
+    client = TestClient(app)
+    resp = client.get("/ui/index.html")
+    assert resp.status_code == 200
+    assert "Pygent API Web UI" in resp.text


### PR DESCRIPTION
## Summary
- mount optional web UI in `create_app`
- run server with UI via new `pygent-web` entrypoint
- implement `web_app.py` and static HTML page
- document the web interface in FastAPI server docs
- test that the UI is served correctly

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7bb7639483218fedfdc729ef0552