### PR TITLE
Add simple web UI to FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ in the container and the result shown in the terminal.
 Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
 For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
-To expose the API over HTTP run `uvicorn pygent.fastapi_app:create_app` (requires `pygent[server]`).
+To expose the API over HTTP run `uvicorn pygent.fastapi_app:create_app` (requires `pygent[server]`). The server also hosts a basic HTML UI at the root URL for quick testing.
 Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 Use `/save DIR` to snapshot the current environment for later use.
 Use `/tools` to enable or disable tools during the session.

--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -23,3 +23,7 @@ The API provides the following endpoints:
 * `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
 
 Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.
+
+## Web Interface
+
+When the server is started a simple HTML interface is served from the root URL. Open your browser at the server address to experiment with the API without writing any code.

--- a/pygent/fastapi_app.py
+++ b/pygent/fastapi_app.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+import os
+
 from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .task_manager import TaskManager
@@ -81,6 +84,10 @@ def create_app() -> FastAPI:
         if task is None:
             raise HTTPException(status_code=404, detail="Task not found")
         return task.agent.history
+
+    static_dir = os.path.join(os.path.dirname(__file__), "static")
+    if os.path.exists(static_dir):
+        app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 
     return app
 

--- a/pygent/static/index.html
+++ b/pygent/static/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Pygent API UI</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    textarea { width: 100%; height: 6em; }
+    input[type=text] { width: 100%; }
+    #history { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Pygent API Web UI</h1>
+  <section>
+    <h2>Start a new task</h2>
+    <textarea id="prompt" placeholder="Enter prompt..."></textarea><br>
+    <button onclick="startTask()">Start Task</button>
+    <p id="taskId"></p>
+  </section>
+
+  <section>
+    <h2>Interact with task</h2>
+    <input type="text" id="task" placeholder="Task ID"><br>
+    <button onclick="checkStatus()">Check Status</button>
+    <p id="status"></p>
+
+    <input type="text" id="message" placeholder="Message"><br>
+    <button onclick="sendMessage()">Send Message</button>
+
+    <button onclick="getHistory()">Get History</button>
+    <div id="history"></div>
+  </section>
+
+<script>
+async function startTask() {
+  const prompt = document.getElementById('prompt').value;
+  const res = await fetch('/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  });
+  const data = await res.json();
+  document.getElementById('taskId').textContent = 'Task ID: ' + data.task_id;
+  document.getElementById('task').value = data.task_id;
+}
+
+async function checkStatus() {
+  const id = document.getElementById('task').value;
+  const res = await fetch(`/tasks/${id}`);
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('status').textContent = 'Status: ' + data.status;
+  }
+}
+
+async function sendMessage() {
+  const id = document.getElementById('task').value;
+  const msg = document.getElementById('message').value;
+  const res = await fetch(`/tasks/${id}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: msg })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    getHistory();
+    alert('Response: ' + data.response);
+  }
+}
+
+async function getHistory() {
+  const id = document.getElementById('task').value;
+  const res = await fetch(`/tasks/${id}/history`);
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('history').textContent = JSON.stringify(data, null, 2);
+  }
+}
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pygent-ui = "pygent.ui:main"
 
 
 [tool.setuptools.package-data]
-"pygent" = ["py.typed"]
+"pygent" = ["py.typed", "static/*"]
 
 [build-system]
 requires = ["setuptools>=64", "wheel"]


### PR DESCRIPTION
## Summary
- add basic HTML UI to interact with the server
- serve static files from the FastAPI app
- include static files in package data
- document the new web UI in README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7bb7639483218fedfdc729ef0552