### PR TITLE
Add API server web interface

### DIFF
--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -23,3 +23,22 @@ The API provides the following endpoints:
 * `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
 
 Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.
+
+## Simple Web Interface
+
+You can interact with the API server through a minimal Gradio front-end. Install
+the optional UI dependencies and run:
+
+```bash
+pip install pygent[ui]
+pygent-api-ui
+```
+
+By default the interface expects the server at `http://localhost:8000`. Pass a
+different URL as the first argument if needed:
+
+```bash
+pygent-api-ui http://your-server:8000
+```
+
+The page lets you chat with the running API server just like the CLI.

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -38,6 +38,10 @@ try:  # optional dependency
     from .fastapi_app import create_app  # noqa: E402,F401
 except Exception:  # pragma: no cover - optional
     create_app = None  # type: ignore
+try:
+    from .api_ui import run_api_gui  # noqa: E402,F401
+except Exception:  # pragma: no cover - optional
+    run_api_gui = None  # type: ignore
 
 __all__ = [
     "Agent",
@@ -63,4 +67,5 @@ __all__ = [
     "AGENT_PRESETS",
     "AgentPreset",
     "create_app",
+    "run_api_gui",
 ]

--- a/pygent/api_ui.py
+++ b/pygent/api_ui.py
@@ -1,0 +1,64 @@
+"""Gradio client for the FastAPI server."""
+
+from __future__ import annotations
+
+from typing import Optional
+import time
+import requests
+
+
+def run_api_gui(api_url: str = "http://localhost:8000") -> None:
+    """Launch a simple chat interface that talks to a running API server."""
+    try:
+        import gradio as gr
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional
+        raise SystemExit(
+            "Gradio is required for the GUI. Install with 'pip install pygent[ui]'"
+        ) from exc
+
+    base = api_url.rstrip("/")
+    task_id: Optional[str] = None
+
+    def _wait_for_completion(tid: str) -> None:
+        while True:
+            resp = requests.get(f"{base}/tasks/{tid}")
+            resp.raise_for_status()
+            if resp.json().get("status") != "running":
+                break
+            time.sleep(0.5)
+
+    def _initial_reply(prompt: str) -> str:
+        nonlocal task_id
+        resp = requests.post(f"{base}/tasks", json={"prompt": prompt})
+        resp.raise_for_status()
+        task_id = resp.json()["task_id"]
+        _wait_for_completion(task_id)
+        hist = requests.get(f"{base}/tasks/{task_id}/history")
+        hist.raise_for_status()
+        for msg in reversed(hist.json()):
+            if msg.get("role") == "assistant":
+                return msg.get("content", "")
+        return ""
+
+    def _send_message(message: str) -> str:
+        resp = requests.post(f"{base}/tasks/{task_id}/message", json={"message": message})
+        resp.raise_for_status()
+        return resp.json().get("response", "")
+
+    def _respond(message: str, history: Optional[list[tuple[str, str]]]) -> str:
+        if task_id is None:
+            return _initial_reply(message)
+        return _send_message(message)
+
+    try:
+        gr.ChatInterface(_respond, title="Pygent API Chat").launch()
+    finally:
+        pass
+
+
+def main() -> None:  # pragma: no cover - optional CLI
+    import sys
+
+    url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8000"
+    run_api_gui(url)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ Repository = "https://github.com/marianochaves/pygent"
 [project.scripts]
 pygent = "pygent.cli:main"
 pygent-ui = "pygent.ui:main"
+pygent-api-ui = "pygent.api_ui:main"
 
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary
- provide `run_api_gui` utility to chat with the FastAPI server
- expose the helper in `__init__` and as the `pygent-api-ui` script
- document the new interface in the FastAPI server guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7bb7639483218fedfdc729ef0552