### PR TITLE
Handle ask_user in FastAPI

### DIFF
--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -19,7 +19,7 @@ The API provides the following endpoints:
 * `POST /tasks` – start a new task. Payload fields match the arguments of `TaskManager.start_task`.
 * `GET /tasks` – list task IDs and their status.
 * `GET /tasks/{task_id}` – retrieve the status of a task.
-* `POST /tasks/{task_id}/message` – send a message to a finished task and get the reply.
+* `POST /tasks/{task_id}/message` – send a message to a finished task and get the reply. The response includes an optional `ask_user` field when the agent requires user input.
 * `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
 
 Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.


### PR DESCRIPTION
## Summary
- detect `ask_user` tool calls in the FastAPI message route
- document the new `ask_user` field in API responses
- test that the FastAPI server returns the `ask_user` payload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d924c9a2083218d31acc9587ec6b3