### PR TITLE
Add OpenAPI spec

### DIFF
--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -22,4 +22,6 @@ The API provides the following endpoints:
 * `POST /tasks/{task_id}/message` – send a message to a finished task and get the reply. The response includes an optional `ask_user` field when the agent requires user input.
 * `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
 
+You can view the full OpenAPI specification in your browser when the server is running at `/docs` or `/openapi.json`. The generated spec is also included in this repository as [`openapi.yaml`](openapi.yaml) for reference.
+
 Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,193 @@
+openapi: 3.1.0
+info:
+  title: FastAPI
+  version: 0.1.0
+paths:
+  /tasks:
+    get:
+      summary: List Tasks
+      operationId: list_tasks_tasks_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+    post:
+      summary: Start Task
+      operationId: start_task_tasks_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/_NewTask'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tasks/{task_id}:
+    get:
+      summary: Task Status
+      operationId: task_status_tasks__task_id__get
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tasks/{task_id}/message:
+    post:
+      summary: Message Task
+      operationId: message_task_tasks__task_id__message_post
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/_UserMessage'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /tasks/{task_id}/history:
+    get:
+      summary: Task History
+      operationId: task_history_tasks__task_id__history_get
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+    _NewTask:
+      properties:
+        prompt:
+          type: string
+          title: Prompt
+        files:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Files
+        persona:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Persona
+        step_timeout:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Step Timeout
+        task_timeout:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Task Timeout
+      type: object
+      required:
+      - prompt
+      title: _NewTask
+    _UserMessage:
+      properties:
+        message:
+          type: string
+          title: Message
+        step_timeout:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Step Timeout
+        max_time:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Max Time
+      type: object
+      required:
+      - message
+      title: _UserMessage


### PR DESCRIPTION
## Summary
- generate `docs/openapi.yaml` using the FastAPI server
- document where to access Swagger in `docs/fastapi-server.md`

## Testing
- `python - <<'EOF'
from pygent.fastapi_app import create_app
import yaml
app = create_app()
openapi = app.openapi()
with open('docs/openapi.yaml', 'w') as f:
    yaml.dump(openapi, f, sort_keys=False)
print('file written')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d9613ef5483219aabfb5fcfe990f7