### PR TITLE
Fix /help crash

### DIFF
--- a/pygent/session.py
+++ b/pygent/session.py
@@ -57,6 +57,8 @@ class Session(ABC):
     def run(self) -> None:
         """Run the interactive loop."""
         from .commands import COMMANDS
+        # Import Agent lazily to avoid circular import issues
+        from .agent import Agent
 
         self.start_message()
         next_msg: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.3.6"
+version = "0.3.7"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]


### PR DESCRIPTION
## Summary
- fix NameError when using `/help` in interactive sessions by importing `Agent` lazily
- bump version to 0.3.7

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a126e8e408321a64fd0976c5dc3ab