### PR TITLE
feat: allow custom system message builder per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,16 @@ All new agents and delegated tasks will use this model unless another one is pas
 You can also override how the assistant builds the system prompt:
 
 ```python
-from pygent.agent import set_system_message_builder
+from pygent import Agent, set_system_message_builder
 
 def my_builder(persona, disabled_tools=None):
     return f"{persona.name}: ready to work"
 
+# Global override
 set_system_message_builder(my_builder)
+
+# Or per-agent
+ag = Agent(system_message_builder=my_builder)
 ```
 
 Passing `None` restores the default prompt generation.

--- a/docs/custom-system-message.md
+++ b/docs/custom-system-message.md
@@ -10,13 +10,24 @@ loaded on start-up.
 
 ```python
 # config.py
-from pygent.agent import set_system_message_builder
+from pygent import set_system_message_builder
 
 
 def my_system_builder(persona, disabled_tools=None):
     return f"{persona.name}: ready to work"
 
 set_system_message_builder(my_system_builder)
+```
+
+You can also supply a builder for individual agents:
+
+```python
+from pygent import Agent
+
+def my_system_builder(persona, disabled_tools=None):
+    return f"{persona.name}: ready to work"
+
+ag = Agent(system_message_builder=my_system_builder)
 ```
 
 Pass `None` to `set_system_message_builder` to restore the default

--- a/docs/prompt-library.md
+++ b/docs/prompt-library.md
@@ -3,7 +3,7 @@
 This page collects a few ready-made system message builders that you can use
 to quickly customise the agent's behaviour. They live in the
 :mod:`pygent.prompt_library` module and work with
-:func:`~pygent.agent.set_system_message_builder`. The
+:func:`~pygent.set_system_message_builder`. The
 :mod:`pygent.agent_presets` module builds on top of these to offer ready-made
 agents with preset tool sets.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.4.0"
+version = "0.4.1"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]

--- a/tests/test_pyconfig.py
+++ b/tests/test_pyconfig.py
@@ -34,13 +34,13 @@ def test_run_py_config_sets_env(tmp_path, monkeypatch):
 def test_run_py_config_sets_system_builder(tmp_path):
     cfg = tmp_path / 'config.py'
     cfg.write_text(
-        'from pygent.agent import set_system_message_builder\n'
+        'from pygent import set_system_message_builder\n'
         'def b(p, disabled_tools=None):\n'
         '    return "CUSTOM"\n'
         'set_system_message_builder(b)\n'
     )
     run_py_config(cfg)
-    from pygent.agent import Agent, set_system_message_builder
+    from pygent import Agent, set_system_message_builder
 
     ag = Agent()
     assert ag.system_msg == "CUSTOM"

--- a/tests/test_system_message_builder.py
+++ b/tests/test_system_message_builder.py
@@ -1,0 +1,17 @@
+import sys
+import types
+
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+
+from pygent.agent import Agent
+
+
+def test_instance_system_message_builder():
+    def b(persona, disabled_tools=None):
+        return f"CUSTOM:{persona.name}"
+
+    ag = Agent(system_message_builder=b)
+    assert ag.system_msg == "CUSTOM:Pygent"
+
+    ag2 = Agent()
+    assert ag2.system_msg != "CUSTOM:Pygent"


### PR DESCRIPTION
## Summary
- allow `Agent` to accept a `system_message_builder` for per-instance system prompts
- document per-agent system message builders and import `set_system_message_builder` from the top-level package
- bump package version to 0.4.1

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894044c588883219c7a2cee668a7e2d