### PR TITLE
Refactor agent/tool/task delegation, simplify CLI, update docs and bump version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Optionally save the history to a JSON file for later recovery.
 * Persist the workspace across sessions by setting `PYGENT_WORKSPACE`.
 * Provides a small Python API for use in other projects.
-* Optional web interface via `pygent ui` (also available as `pygent-ui`).
-* Optional FastAPI server to manage tasks over HTTP.
 * Register your own tools and customise the system prompt.
 * Extend the CLI with custom commands.
-* Build custom interactive sessions by subclassing the `Session` API.
 * Execute a `config.py` script on startup for advanced configuration.
 * Set environment variables from the command line.
-* Each session begins with a short plan that you can approve before execution.
 * The assistant can leverage the `bash` tool to run shell commands in a sandboxed environment.
 
 ## Installation
@@ -28,10 +24,10 @@ The recommended way to install Pygent is using pip:
 pip install pygent
 ```
 
-To include optional features like Docker support, the web UI, or the FastAPI server, you can specify extras:
+To include optional Docker support, you can specify extras:
 
 ```bash
-pip install pygent[docker,ui,server]
+pip install pygent[docker]
 ```
 
 Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
@@ -44,7 +40,7 @@ pip install -e .
 ```
 
 Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
-To run commands in Docker containers, Docker must be installed separately. If installing from source, you can include Docker support with `pip install -e .[docker,ui,server]`.
+To run commands in Docker containers, Docker must be installed separately. If installing from source, you can include Docker support with `pip install -e .[docker]`.
 
 ## Configuration
 
@@ -57,13 +53,12 @@ Behaviour can be adjusted via environment variables (see `docs/configuration.md`
 * `PYGENT_MODEL` &ndash; model name used for requests (default `gpt-4.1-mini`).
 * `PYGENT_IMAGE` &ndash; Docker image to create the container (default `python:3.12-slim`).
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
-* `PYGENT_MAX_TASKS` &ndash; maximum number of concurrent delegated tasks (default `3`).
 
 Settings can also be read from a `pygent.toml` file. See
 [examples/sample_config.toml](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)
 and the accompanying
 [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py)
-script for a working demonstration that generates tests using a delegated agent.
+script for a working demonstration of startup configuration.
 
 ## CLI usage
 
@@ -87,8 +82,6 @@ Type messages normally; use `/exit` to end the session. Each command is executed
 in the container and the result shown in the terminal.
 Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
-For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
-To expose the API over HTTP run `uvicorn pygent.fastapi_app:create_app` (requires `pygent[server]`).
 Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 Use `/save DIR` to snapshot the current environment for later use.
 Use `/tools` to enable or disable tools during the session.
@@ -128,7 +121,7 @@ from pygent.models import set_custom_model
 set_custom_model(MyModel())
 ```
 
-All new agents and delegated tasks will use this model unless another one is passed explicitly.
+All new agents will use this model unless another one is passed explicitly.
 
 You can also override how the assistant builds the system prompt:
 
@@ -182,4 +175,3 @@ Use `mkdocs serve` to build the documentation locally and serve it on a local we
 ## License
 
 This project is released under the MIT license. See the `LICENSE` file for details.
-

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,8 +13,6 @@ To start an interactive session, simply run `pygent` in your terminal. You can u
 * `--load <dir>`: Loads a snapshot of a previously saved environment, including the workspace, history, and environment variables.
 * `--confirm-bash`: Prompts for confirmation before executing any command with the `bash` tool. The command is shown in the terminal before asking for permission.
 * `--ban-cmd <command>`: Disables the execution of a specific command.
-* `--preset <name>`: Starts the session using one of the built-in presets
-  (`autonomous`, `assistant`, or `reviewer`).
 
 ## Internal Commands
 

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -30,14 +30,6 @@ from .session import Session, CliSession
 from .models import Model, OpenAIModel, set_custom_model  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool, clear_tools, reset_tools, remove_tool  # noqa: E402,F401
-from .task_manager import TaskManager  # noqa: E402,F401
-from .task_tools import register_task_tools  # noqa: E402,F401
-from .prompt_library import PROMPT_BUILDERS  # noqa: E402,F401
-from .agent_presets import AGENT_PRESETS, AgentPreset  # noqa: E402,F401
-try:  # optional dependency
-    from .fastapi_app import create_app  # noqa: E402,F401
-except Exception:  # pragma: no cover - optional
-    create_app = None  # type: ignore
 
 __all__ = [
     "Agent",
@@ -57,10 +49,4 @@ __all__ = [
     "clear_tools",
     "reset_tools",
     "remove_tool",
-    "TaskManager",
-    "register_task_tools",
-    "PROMPT_BUILDERS",
-    "AGENT_PRESETS",
-    "AgentPreset",
-    "create_app",
 ]

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -1,47 +1,60 @@
-"""Orchestration layer: receives messages, calls the OpenAI-compatible backend and dispatches tools."""
+"""Orchestration layer: receives messages, calls the model, and dispatches tools."""
 
 import json
 import os
 import pathlib
-import uuid
 import time
-from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional, Callable
+from contextlib import nullcontext
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional
 
 from rich.console import Console
-from rich.panel import Panel
 from rich.markdown import Markdown
+from rich.panel import Panel
+
 try:
     from rich import __version__ as _rich_version  # noqa: F401
 except Exception:  # pragma: no cover - tests may stub out rich
     import rich as _rich
+
     if not hasattr(_rich, "__version__"):
         _rich.__version__ = "0"
     if not hasattr(_rich, "__file__"):
         _rich.__file__ = "rich-not-installed"
+
 try:
     from rich import box  # type: ignore
-except Exception:  # pragma: no cover - tests stub out rich
+except Exception:  # pragma: no cover - tests may stub out rich
     box = None
-from contextlib import nullcontext
+
 try:  # pragma: no cover - optional dependency
     import questionary  # type: ignore
 except Exception:  # pragma: no cover - used in tests without questionary
     questionary = None
 
-from .runtime import Runtime
-from . import tools, models, openai_compat
-from .session import CliSession
+from . import models, openai_compat, tools
 from .models import Model, OpenAIModel
 from .persona import Persona
+from .runtime import Runtime
+from .session import CliSession
 from .system_message import DEFAULT_PERSONA, build_system_msg
 
 DEFAULT_MODEL = os.getenv("PYGENT_MODEL", "gpt-4.1-mini")
 console = Console()
 
 
+def _safe_print(*args: Any, **kwargs: Any) -> None:
+    if console is not None and hasattr(console, "print"):
+        console.print(*args, **kwargs)
+
+
+def _status(message: str, spinner: str):
+    if console is not None and hasattr(console, "status"):
+        return console.status(message, spinner=spinner)
+    return nullcontext()
+
+
 def _default_model() -> Model:
-    """Return the global custom model or the default OpenAI model."""
     return models.CUSTOM_MODEL or OpenAIModel()
 
 
@@ -62,6 +75,7 @@ def _default_confirm_bash() -> bool:
 @dataclass
 class Agent:
     """Interactive assistant handling messages and tool execution."""
+
     runtime: Runtime = field(default_factory=Runtime)
     model: Model = field(default_factory=_default_model)
     model_name: str = DEFAULT_MODEL
@@ -76,37 +90,40 @@ class Agent:
     max_non_tool_replies: Optional[int] = None
 
     def __post_init__(self) -> None:
-        """Initialize defaults after dataclass construction."""
         self._log_fp = None
         if not self.system_msg:
             self.refresh_system_message()
-        if self.history_file and isinstance(self.history_file, (str, pathlib.Path)):
-            self.history_file = pathlib.Path(self.history_file)
-            if self.history_file.is_file():
-                try:
-                    with self.history_file.open("r", encoding="utf-8") as fh:
-                        data = json.load(fh)
-                except Exception:
-                    data = []
-                self.history = [
-                    openai_compat.parse_message(m) if isinstance(m, dict) else m
-                    for m in data
-                ]
+        self._restore_history_file()
         if not self.history:
             self.append_history({"role": "system", "content": self.system_msg})
+        self._init_log_file()
+
+    def _restore_history_file(self) -> None:
+        if not self.history_file or not isinstance(self.history_file, (str, pathlib.Path)):
+            return
+        self.history_file = pathlib.Path(self.history_file)
+        if not self.history_file.is_file():
+            return
+        try:
+            with self.history_file.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = []
+        self.history = [openai_compat.parse_message(m) if isinstance(m, dict) else m for m in data]
+
+    def _init_log_file(self) -> None:
         if self.log_file is None:
-            if hasattr(self.runtime, "base_dir"):
-                self.log_file = pathlib.Path(getattr(self.runtime, "base_dir")) / "cli.log"
-            else:
-                self.log_file = pathlib.Path("cli.log")
-        if isinstance(self.log_file, (str, pathlib.Path)):
-            self.log_file = pathlib.Path(self.log_file)
-            os.environ.setdefault("PYGENT_LOG_FILE", str(self.log_file))
-            self.log_file.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                self._log_fp = self.log_file.open("a", encoding="utf-8")
-            except Exception:
-                self._log_fp = None
+            base_dir = getattr(self.runtime, "base_dir", None)
+            self.log_file = pathlib.Path(base_dir) / "cli.log" if base_dir else pathlib.Path("cli.log")
+        if not isinstance(self.log_file, (str, pathlib.Path)):
+            return
+        self.log_file = pathlib.Path(self.log_file)
+        os.environ.setdefault("PYGENT_LOG_FILE", str(self.log_file))
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._log_fp = self.log_file.open("a", encoding="utf-8")
+        except Exception:
+            self._log_fp = None
 
     def _message_dict(self, msg: Any) -> Dict[str, Any]:
         if isinstance(msg, dict):
@@ -119,10 +136,11 @@ class Agent:
         raise TypeError(f"Unsupported message type: {type(msg)!r}")
 
     def _save_history(self) -> None:
-        if self.history_file:
-            self.history_file.parent.mkdir(parents=True, exist_ok=True)
-            with self.history_file.open("w", encoding="utf-8") as fh:
-                json.dump([self._message_dict(m) for m in self.history], fh)
+        if not self.history_file:
+            return
+        self.history_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.history_file.open("w", encoding="utf-8") as fh:
+            json.dump([self._message_dict(m) for m in self.history], fh)
 
     def append_history(self, msg: Any) -> None:
         self.history.append(msg)
@@ -135,15 +153,94 @@ class Agent:
                 pass
 
     def refresh_system_message(self) -> None:
-        """Update the system prompt based on the current tool registry."""
         if self.system_message_builder:
-            self.system_msg = self.system_message_builder(
-                self.persona, self.disabled_tools
-            )
+            self.system_msg = self.system_message_builder(self.persona, self.disabled_tools)
         else:
             self.system_msg = build_system_msg(self.persona, self.disabled_tools)
         if self.history and self.history[0].get("role") == "system":
             self.history[0]["content"] = self.system_msg
+
+    def _active_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            schema
+            for schema in tools.TOOL_SCHEMAS
+            if schema["function"]["name"] not in self.disabled_tools
+        ]
+
+    def _confirm_bash_call(self, call: openai_compat.ToolCall) -> bool:
+        if not (self.confirm_bash and call.function.name == "bash"):
+            return True
+        args = json.loads(call.function.arguments or "{}")
+        cmd = args.get("cmd", "")
+        _safe_print(
+            Panel(
+                f"$ {cmd}",
+                title=f"[bold yellow]{self.persona.name} pending bash[/]",
+                border_style="yellow",
+                box=box.HEAVY_HEAD if box else None,
+                title_align="left",
+            )
+        )
+        prompt = "Run this command?"
+        if questionary:
+            approved = questionary.confirm(prompt, default=True).ask()
+        elif console is not None and hasattr(console, "input"):  # pragma: no cover - fallback for tests
+            answer = console.input(f"{prompt} [Y/n]: ").lower()
+            approved = answer == "" or answer.startswith("y")
+        else:
+            approved = False
+        if approved:
+            return True
+
+        output = f"$ {cmd}\n[bold red]Aborted by user.[/]"
+        self.append_history({"role": "tool", "content": output, "tool_call_id": call.id})
+        _safe_print(
+            Panel(
+                output,
+                title=f"[bold red]{self.persona.name} tool:{call.function.name}[/]",
+                border_style="red",
+                box=box.ROUNDED if box else None,
+                title_align="left",
+            )
+        )
+        return False
+
+    def _display_tool_output(self, call: openai_compat.ToolCall, output: str) -> None:
+        if call.function.name in {"ask_user", "stop"}:
+            return
+
+        display_output = output
+        if call.function.name == "read_image" and output.startswith("data:image"):
+            try:
+                args = json.loads(call.function.arguments or "{}")
+                path = args.get("path", "<unknown>")
+                self.append_history(
+                    {
+                        "role": "user",
+                        "content": [{"type": "image_url", "image_url": {"url": output}}],
+                    }
+                )
+            except Exception:
+                path = "<unknown>"
+            display_output = f"returned data URL for {path}"
+
+        _safe_print(
+            Panel(
+                display_output,
+                title=f"[bold bright_blue]{self.persona.name} tool:{call.function.name}[/]",
+                border_style="bright_blue",
+                box=box.ROUNDED if box else None,
+                title_align="left",
+            )
+        )
+
+    def _execute_tool_call(self, call: openai_compat.ToolCall) -> None:
+        if not self._confirm_bash_call(call):
+            return
+        with _status(f"[green]Running {call.function.name}...", spinner="line"):
+            output = tools.execute_tool(call, self.runtime)
+        self.append_history({"role": "tool", "content": output, "tool_call_id": call.id})
+        self._display_tool_output(call, output)
 
     def step(self, user_msg: str = None, role: str = "user") -> openai_compat.Message:
         """Execute one round of interaction with the model."""
@@ -152,104 +249,19 @@ class Agent:
         if user_msg:
             self.append_history({"role": role, "content": user_msg})
 
-        status_cm = (
-            console.status("[bold cyan]Thinking...", spinner="dots")
-            if hasattr(console, "status")
-            else nullcontext()
-        )
-        schemas = [
-            s
-            for s in tools.TOOL_SCHEMAS
-            if s["function"]["name"] not in self.disabled_tools
-        ]
-        with status_cm:
-            assistant_raw = self.model.chat(
-                self.history, self.model_name, schemas
-            )
+        with _status("[bold cyan]Thinking...", spinner="dots"):
+            assistant_raw = self.model.chat(self.history, self.model_name, self._active_schemas())
+
         assistant_msg = openai_compat.parse_message(assistant_raw)
         self.append_history(assistant_msg)
 
         if assistant_msg.tool_calls:
             for call in assistant_msg.tool_calls:
-                if self.confirm_bash and call.function.name == "bash":
-                    args = json.loads(call.function.arguments or "{}")
-                    cmd = args.get("cmd", "")
-                    console.print(
-                        Panel(
-                            f"$ {cmd}",
-                            title=f"[bold yellow]{self.persona.name} pending bash[/]",
-                            border_style="yellow",
-                            box=box.HEAVY_HEAD if box else None,
-                            title_align="left",
-                        )
-                    )
-                    prompt = "Run this command?"
-                    if questionary:
-                        ok = questionary.confirm(prompt, default=True).ask()
-                    else:  # pragma: no cover - fallback for tests
-                        ok_input = console.input(f"{prompt} [Y/n]: ").lower()
-                        ok = ok_input == "" or ok_input.startswith("y")
-                    if not ok:
-                        output = f"$ {cmd}\n[bold red]Aborted by user.[/]"
-                        self.append_history({"role": "tool", "content": output, "tool_call_id": call.id})
-                        console.print(
-                            Panel(
-                                output,
-                                title=f"[bold red]{self.persona.name} tool:{call.function.name}[/]",
-                                border_style="red",
-                                box=box.ROUNDED if box else None,
-                                title_align="left",
-                            )
-                        )
-                        continue
-                status_cm = (
-                    console.status(
-                        f"[green]Running {call.function.name}...", spinner="line"
-                    )
-                    if hasattr(console, "status")
-                    else nullcontext()
-                )
-                with status_cm:
-                    output = tools.execute_tool(call, self.runtime)
-                self.append_history(
-                    {"role": "tool", "content": output, "tool_call_id": call.id}
-                )
-                if call.function.name not in {"ask_user", "stop"}:
-                    display_output = output
-                    if call.function.name == "read_image" and output.startswith("data:image"):
-                        try:
-                            args = json.loads(call.function.arguments or "{}")
-                            path = args.get("path", "<unknown>")
-                            self.append_history(
-                                {
-                                    "role": "user",
-                                    "content": [
-                                        {
-                                            "type": "image_url",
-                                            "image_url": {
-                                                "url": output
-                                            }
-                                        }
-                                    ]
-                                }
-                            )
-                        except Exception:
-                            path = "<unknown>"
-                        display_output = f"returned data URL for {path}"
-                    console.print(
-                        Panel(
-                            display_output,
-                            title=f"[bold bright_blue]{self.persona.name} tool:{call.function.name}[/]",
-                            border_style="bright_blue",
-                            box=box.ROUNDED if box else None,
-                            title_align="left",
-                        )
-                    )
+                self._execute_tool_call(call)
         else:
-            markdown_response = Markdown(assistant_msg.content or "") # Ensure content is not None
-            console.print(
+            _safe_print(
                 Panel(
-                    markdown_response,
+                    Markdown(assistant_msg.content or ""),
                     title=f"[bold green]{self.persona.name} replied[/]",
                     title_align="left",
                     border_style="green",
@@ -265,11 +277,7 @@ class Agent:
         step_timeout: Optional[float] = None,
         max_time: Optional[float] = None,
     ) -> Optional[openai_compat.Message]:
-        """Run steps until ``stop`` is called or limits are reached.
-
-        The agent also stops if it replies without using a tool more than
-        ``max_non_tool_replies`` times consecutively.
-        """
+        """Run steps until ``stop`` is called or limits are reached."""
 
         if step_timeout is None:
             env = os.getenv("PYGENT_STEP_TIMEOUT")
@@ -278,57 +286,46 @@ class Agent:
             env = os.getenv("PYGENT_TASK_TIMEOUT")
             max_time = float(env) if env else None
 
-        msg = user_msg
+        msg: Optional[str] = user_msg
         start = time.monotonic()
         self._timed_out = False
         last_msg = None
         non_tool_replies = 0
-        for _ in range(max_steps):
+
+        for idx in range(max_steps):
             if max_time is not None and time.monotonic() - start > max_time:
-                self.append_history(
-                    {"role": "system", "content": f"[timeout after {max_time}s]"}
-                )
+                self.append_history({"role": "system", "content": f"[timeout after {max_time}s]"})
                 self._timed_out = True
                 break
+
             step_start = time.monotonic()
-            if msg==user_msg:
-              role = 'user'
-            else:
-              role = 'system'
+            role = "user" if idx == 0 else "system"
             assistant_msg = self.step(msg, role=role)
             last_msg = assistant_msg
-            if (
-                step_timeout is not None
-                and time.monotonic() - step_start > step_timeout
-            ):
-                self.append_history(
-                    {"role": "system", "content": f"[timeout after {step_timeout}s]"}
-                )
+
+            if step_timeout is not None and time.monotonic() - step_start > step_timeout:
+                self.append_history({"role": "system", "content": f"[timeout after {step_timeout}s]"})
                 self._timed_out = True
                 break
+
             calls = assistant_msg.tool_calls or []
             if any(c.function.name in ("stop", "ask_user") for c in calls):
                 break
+
             if calls:
                 non_tool_replies = 0
             else:
                 non_tool_replies += 1
-                if (
-                    self.max_non_tool_replies is not None
-                    and non_tool_replies >= self.max_non_tool_replies
-                ):
+                if self.max_non_tool_replies is not None and non_tool_replies >= self.max_non_tool_replies:
                     self.append_history(
-                        {
-                            "role": "system",
-                            "content": "[stopped after too many non-tool replies]",
-                        }
+                        {"role": "system", "content": "[stopped after too many non-tool replies]"}
                     )
                     break
             msg = None
+
         return last_msg
 
     def close(self) -> None:
-        """Close any open resources."""
         if self._log_fp:
             try:
                 self._log_fp.close()
@@ -342,30 +339,13 @@ def run_interactive(
     disabled_tools: Optional[List[str]] = None,
     confirm_bash: Optional[bool] = None,
     banned_commands: Optional[List[str]] = None,
-    preset: Optional[str] = None,
 ) -> None:  # pragma: no cover
-    """Start an interactive session in the terminal.
+    """Start an interactive session in the terminal."""
 
-    Parameters
-    ----------
-    preset:
-        Name of a preset from :data:`pygent.agent_presets.AGENT_PRESETS` to use
-        when creating the agent.
-    """
     ws = pathlib.Path.cwd() / workspace_name if workspace_name else None
-    if preset:
-        from .agent_presets import AGENT_PRESETS
-
-        agent = AGENT_PRESETS[preset].create_agent(
-            runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
-            disabled_tools=disabled_tools or [],
-            confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
-        )
-    else:
-        agent = Agent(
-            runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
-            disabled_tools=disabled_tools or [],
-            confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
-        )
-    session = CliSession(agent)
-    session.run()
+    agent = Agent(
+        runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
+        disabled_tools=disabled_tools or [],
+        confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
+    )
+    CliSession(agent).run()

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -8,7 +8,6 @@ import os
 import typer
 
 from .config import load_config, run_py_config, load_snapshot
-from .agent_presets import AGENT_PRESETS
 
 
 app = typer.Typer(invoke_without_command=True, help="Pygent command line interface")
@@ -73,12 +72,6 @@ def main(
         help="command to ban (repeatable)",
         show_default=False,
     ),
-    preset: Optional[str] = typer.Option(
-        None,
-        "--preset",
-        help="start session using a predefined agent preset (autonomous, assistant, reviewer)",
-        show_default=False,
-    ),
 ) -> None:  # pragma: no cover - CLI wrapper
     """Start an interactive session when no subcommand is given."""
     load_config(config)
@@ -102,7 +95,6 @@ def main(
         "omit_tool": omit_tool or [],
         "confirm_bash": confirm_bash,
         "ban_cmd": ban_cmd or [],
-        "preset": preset,
     }
     if ctx.invoked_subcommand is None:
         from .agent import run_interactive
@@ -113,7 +105,6 @@ def main(
             disabled_tools=omit_tool or [],
             confirm_bash=confirm_bash,
             banned_commands=ban_cmd or [],
-            preset=preset,
         )
         raise typer.Exit()
 
@@ -143,4 +134,3 @@ def run() -> None:  # pragma: no cover
 
 
 main = run  # Backwards compatibility
-

--- a/pygent/task_tools.py
+++ b/pygent/task_tools.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Optional tools for background tasks and personas."""
 
 import json
-from typing import Optional, List
+from typing import Optional
 
 from .runtime import Runtime
 from .task_manager import TaskManager
@@ -19,15 +19,78 @@ def _get_manager() -> TaskManager:
     return _task_manager
 
 
+def get_task_manager() -> TaskManager:
+    """Return the lazily-created manager used by task tools."""
+    return _get_manager()
+
+
+def set_task_manager(manager: TaskManager) -> None:
+    """Override the manager instance (used by tests and integration layers)."""
+    global _task_manager
+    _task_manager = manager
+
+
 # ---- tool implementations ----
-from .tools import (
-    _delegate_task,
-    _delegate_persona_task,
-    _list_personas,
-    _task_status,
-    _collect_file,
-    _download_file,
-)
+from .tools import _download_file
+
+
+def _delegate_task(
+    rt: Runtime,
+    prompt: str,
+    files: Optional[list[str]] = None,
+    timeout: Optional[float] = None,
+    step_timeout: Optional[float] = None,
+    persona: Optional[str] = None,
+) -> str:
+    if getattr(rt, "task_depth", 0) >= 1:
+        return "error: delegation not allowed in sub-tasks"
+    try:
+        tid = _get_manager().start_task(
+            prompt,
+            parent_rt=rt,
+            files=files,
+            parent_depth=getattr(rt, "task_depth", 0),
+            step_timeout=step_timeout,
+            task_timeout=timeout,
+            persona=persona,
+        )
+    except RuntimeError as exc:
+        return str(exc)
+    return f"started {tid}"
+
+
+def _delegate_persona_task(
+    rt: Runtime,
+    prompt: str,
+    persona: str,
+    files: Optional[list[str]] = None,
+    timeout: Optional[float] = None,
+    step_timeout: Optional[float] = None,
+) -> str:
+    return _delegate_task(
+        rt,
+        prompt=prompt,
+        files=files,
+        timeout=timeout,
+        step_timeout=step_timeout,
+        persona=persona,
+    )
+
+
+def _list_personas(rt: Runtime) -> str:
+    personas = [
+        {"name": p.name, "description": p.description}
+        for p in _get_manager().personas
+    ]
+    return json.dumps(personas)
+
+
+def _task_status(rt: Runtime, task_id: str) -> str:
+    return _get_manager().status(task_id)
+
+
+def _collect_file(rt: Runtime, task_id: str, path: str, dest: Optional[str] = None) -> str:
+    return _get_manager().collect_file(rt, task_id, path, dest)
 
 
 def register_task_tools() -> None:

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -9,21 +9,12 @@ from pathlib import Path
 from copy import deepcopy
 
 from .runtime import Runtime
-from .task_manager import TaskManager
-
-_task_manager: Optional[TaskManager] = None
-
-
-def _get_manager() -> TaskManager:
-    global _task_manager
-    if _task_manager is None:
-        _task_manager = TaskManager()
-    return _task_manager
 
 
 # ---- registry ----
 TOOLS: Dict[str, Callable[..., str]] = {}
 TOOL_SCHEMAS: List[Dict[str, Any]] = []
+_task_manager: Any = None
 
 
 def register_tool(
@@ -149,73 +140,55 @@ def _ask_user(
 ) -> str:  # pragma: no cover - side-effect free
     return "Continuing the conversation."
 
-
-
-
-def _delegate_task(
-    rt: Runtime,
-    prompt: str,
-    files: Optional[list[str]] = None,
-    timeout: Optional[float] = None,
-    step_timeout: Optional[float] = None,
-    persona: Optional[str] = None,
-) -> str:
-    if getattr(rt, "task_depth", 0) >= 1:
-        return "error: delegation not allowed in sub-tasks"
-    try:
-        tid = _get_manager().start_task(
-            prompt,
-            parent_rt=rt,
-            files=files,
-            parent_depth=getattr(rt, "task_depth", 0),
-            step_timeout=step_timeout,
-            task_timeout=timeout,
-            persona=persona,
-        )
-    except RuntimeError as exc:
-        return str(exc)
-    return f"started {tid}"
-
-
-def _delegate_persona_task(
-    rt: Runtime,
-    prompt: str,
-    persona: str,
-    files: Optional[list[str]] = None,
-    timeout: Optional[float] = None,
-    step_timeout: Optional[float] = None,
-) -> str:
-    return _delegate_task(
-        rt,
-        prompt=prompt,
-        files=files,
-        timeout=timeout,
-        step_timeout=step_timeout,
-        persona=persona,
-    )
-
-
-def _list_personas(rt: Runtime) -> str:
-    """Return JSON list of personas."""
-    personas = [
-        {"name": p.name, "description": p.description}
-        for p in _get_manager().personas
-    ]
-    return json.dumps(personas)
-
-
-def _task_status(rt: Runtime, task_id: str) -> str:
-    return _get_manager().status(task_id)
-
-
-def _collect_file(rt: Runtime, task_id: str, path: str, dest: Optional[str] = None) -> str:
-    """Retrieve a file or directory from a delegated task."""
-    return _get_manager().collect_file(rt, task_id, path, dest)
-
-
 def _download_file(rt: Runtime, path: str, binary: bool = False) -> str:
     """Return the contents of a file from the workspace."""
     return rt.read_file(path, binary=binary)
+
+
+# Legacy wrappers kept outside the default tool registry so the core package
+# stays focused on a single-agent CLI flow.
+def _sync_task_manager() -> None:
+    from . import task_tools
+
+    if _task_manager is not None:
+        task_tools.set_task_manager(_task_manager)
+    else:
+        globals()["_task_manager"] = task_tools.get_task_manager()
+
+
+def _delegate_task(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._delegate_task(*args, **kwargs)
+
+
+def _delegate_persona_task(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._delegate_persona_task(*args, **kwargs)
+
+
+def _list_personas(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._list_personas(*args, **kwargs)
+
+
+def _task_status(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._task_status(*args, **kwargs)
+
+
+def _collect_file(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._collect_file(*args, **kwargs)
 
 
 @tool(
@@ -272,4 +245,3 @@ def remove_tool(name: str) -> None:
         if func.get("name") == name:
             TOOL_SCHEMAS.pop(i)
             break
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.4.2"
+version = "1.0.0"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]


### PR DESCRIPTION
### Motivation

- Simplify the single-agent CLI flow by removing legacy multi-task default wiring and making task delegation explicit and optional. 
- Improve agent robustness by encapsulating history/log handling and making console/status printing safer for test environments. 
- Update documentation and packaging metadata to reflect the trimmed optional extras and a new major version.

### Description

- Reworked `Agent` to factor out printing/status helpers (`_safe_print`, `_status`), restore history/log initialization (`_restore_history_file`, `_init_log_file`), and centralize tool execution and display logic (`_active_schemas`, `_confirm_bash_call`, `_display_tool_output`, `_execute_tool_call`).
- Simplified `run_interactive` and removed preset-based agent construction and related exports from `__init__.py`, and removed direct optional FastAPI app import; simplified CLI entry in `pygent/cli.py` by dropping the `--preset` option.
- Split and reorganized task-related tooling: created/expanded `pygent/task_tools.py` to own task manager helpers and task tool implementations, and refactored `pygent/tools.py` to lazily synchronize with `task_tools` when delegation features are used while keeping core built-in tools smaller and independent.
- Updated documentation and README: removed references to the simple web UI and FastAPI server from main install extras and usage, adjusted install extras to `pygent[docker]` and clarified source install extras, and updated several help texts.
- Bumped package version in `pyproject.toml` from `0.4.2` to `1.0.0`.

### Testing

- Ran the unit test suite with `pytest`; test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea507fcf48321a56a8cfbf4a523ac)