### PR TITLE
Make single-agent CLI the default; refactor task tools as optional legacy layer and improve Agent tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ Pygent is a coding assistant that executes each request inside an isolated Docke
 * Optionally save the history to a JSON file for later recovery.
 * Persist the workspace across sessions by setting `PYGENT_WORKSPACE`.
 * Provides a small Python API for use in other projects.
-* Optional web interface via `pygent ui` (also available as `pygent-ui`).
-* Optional FastAPI server to manage tasks over HTTP.
 * Register your own tools and customise the system prompt.
 * Extend the CLI with custom commands.
-* Build custom interactive sessions by subclassing the `Session` API.
 * Execute a `config.py` script on startup for advanced configuration.
 * Set environment variables from the command line.
-* Each session begins with a short plan that you can approve before execution.
 * The assistant can leverage the `bash` tool to run shell commands in a sandboxed environment.
 
 ## Installation
@@ -28,10 +24,10 @@ The recommended way to install Pygent is using pip:
 pip install pygent
 ```
 
-To include optional features like Docker support, the web UI, or the FastAPI server, you can specify extras:
+To include optional Docker support, you can specify extras:
 
 ```bash
-pip install pygent[docker,ui,server]
+pip install pygent[docker]
 ```
 
 Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
@@ -44,7 +40,7 @@ pip install -e .
 ```
 
 Python ≥ 3.9 is required. The package now bundles the `openai` client for model access.
-To run commands in Docker containers, Docker must be installed separately. If installing from source, you can include Docker support with `pip install -e .[docker,ui,server]`.
+To run commands in Docker containers, Docker must be installed separately. If installing from source, you can include Docker support with `pip install -e .[docker]`.
 
 ## Configuration
 
@@ -57,13 +53,12 @@ Behaviour can be adjusted via environment variables (see `docs/configuration.md`
 * `PYGENT_MODEL` &ndash; model name used for requests (default `gpt-4.1-mini`).
 * `PYGENT_IMAGE` &ndash; Docker image to create the container (default `python:3.12-slim`).
 * `PYGENT_USE_DOCKER` &ndash; set to `0` to disable Docker and run locally.
-* `PYGENT_MAX_TASKS` &ndash; maximum number of concurrent delegated tasks (default `3`).
 
 Settings can also be read from a `pygent.toml` file. See
 [examples/sample_config.toml](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)
 and the accompanying
 [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py)
-script for a working demonstration that generates tests using a delegated agent.
+script for a working demonstration of startup configuration.
 
 ## CLI usage
 
@@ -87,8 +82,6 @@ Type messages normally; use `/exit` to end the session. Each command is executed
 in the container and the result shown in the terminal.
 Interactive programs that expect input (e.g. running `python` without a script)
 are not supported and will exit immediately.
-For a minimal web interface run `pygent ui` instead (requires `pygent[ui]`).
-To expose the API over HTTP run `uvicorn pygent.fastapi_app:create_app` (requires `pygent[server]`).
 Use `/help` for a list of built-in commands or `/help <cmd>` for details.
 Use `/save DIR` to snapshot the current environment for later use.
 Use `/tools` to enable or disable tools during the session.
@@ -128,7 +121,7 @@ from pygent.models import set_custom_model
 set_custom_model(MyModel())
 ```
 
-All new agents and delegated tasks will use this model unless another one is passed explicitly.
+All new agents will use this model unless another one is passed explicitly.
 
 You can also override how the assistant builds the system prompt:
 
@@ -182,4 +175,3 @@ Use `mkdocs serve` to build the documentation locally and serve it on a local we
 ## License
 
 This project is released under the MIT license. See the `LICENSE` file for details.
-

--- a/docs/agent-presets.md
+++ b/docs/agent-presets.md
@@ -1,31 +1,23 @@
-# Agent Presets
+# Agent Presets (Legacy)
 
-The :mod:`pygent.agent_presets` module bundles ready-made configurations for common
-workflows. Each preset combines a system message builder from the
-:mod:`pygent.prompt_library` with a default set of tools.
+> Legacy note: presets are no longer part of the default CLI architecture.
 
-Use :data:`~pygent.agent_presets.AGENT_PRESETS` to select one:
+The old `pygent.agent_presets` module still exists for compatibility in some setups,
+but the recommended approach is now to configure behavior directly with:
+
+* `set_system_message_builder(...)`
+* tool enable/disable controls
+
+## Migration path
+
+Instead of presets:
 
 ```python
-from pygent import AGENT_PRESETS
+from pygent import Agent, set_system_message_builder
+from pygent.prompt_library import PROMPT_BUILDERS
 
-ag = AGENT_PRESETS["autonomous"].create_agent()
-ag.run_until_stop("echo hello")
+set_system_message_builder(PROMPT_BUILDERS["autonomous"])
+ag = Agent()
 ```
 
-The available presets and their behaviours are:
-
-| Name | Tools | Description |
-| --- | --- | --- |
-| ``autonomous`` | ``bash``, ``write_file``, ``stop`` | Operates autonomously in a computing environment with no further user messages. It inspects the environment first, executes the task in steps, tests the result and ends with a final artefact or summary using ``stop``. |
-| ``assistant`` | ``bash``, ``write_file``, ``ask_user`` | Interactive style that asks for clarifications and presents menu options when possible. |
-| ``reviewer`` | ``bash`` | Focuses on analysing code and suggesting improvements. |
-
-You can create your own preset by instantiating
-:class:`~pygent.agent_presets.AgentPreset` with a custom builder and tool list.
-
-To start an interactive session using a preset from the command line:
-
-```bash
-pygent --preset autonomous
-```
+For CLI sessions, start plain `pygent` and adjust tools interactively (`/tools`).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,39 +1,47 @@
 # API Reference
 
-This section documents the main classes and helpers exposed by **Pygent**. The content is generated from the package docstrings.
+This section documents the main classes and helpers exposed by **Pygent**.
 
-## Agent
+## Core API
+
+### Agent
 
 ::: pygent.agent.Agent
 
-## Runtime
+### Runtime
 
 ::: pygent.runtime.Runtime
 
-## TaskManager
-
-::: pygent.task_manager.TaskManager
-
-## Tools
+### Tools
 
 ::: pygent.tools
 
-## Models
+### Models
 
 ::: pygent.models
 
-## Config
+### Config
 
 ::: pygent.config
 
-## Errors
+### Errors
 
 ::: pygent.errors
 
-## OpenAI Compatibility (`openai_compat`)
+### OpenAI Compatibility (`openai_compat`)
 
 ::: pygent.openai_compat
 
-## Commands
+### Commands
 
 ::: pygent.commands
+
+## Optional legacy API
+
+### TaskManager
+
+::: pygent.task_manager.TaskManager
+
+### Task tools module
+
+::: pygent.task_tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,25 +1,27 @@
 # Architecture
 
-Understanding Pygent's architecture helps in effectively customizing and extending the project. The system is composed of a few main components that work together.
+Pygent now prioritizes a **simple single-agent architecture**.
 
-## Core Components
+## Core components
 
-* **`Agent`**: The `Agent` is the central orchestrator. It maintains the conversation history, interacts with the language model to decide the next step, and dispatches calls to tools. Each agent has its own state, including its persona and enabled tools.
+* **`Agent`**: orchestrates messages, model calls, and tool execution.
+* **`Runtime`**: executes commands and file operations in local or Docker workspace.
+* **`Model`** (`OpenAIModel` by default): abstraction for OpenAI-compatible chat backends.
+* **`tools` registry**: global registry used to expose callable actions to the model.
 
-* **`Runtime`**: The `Runtime` represents the isolated execution environment. It is responsible for executing commands (`bash`), interacting with the file system (`write_file`, `read_file`), and managing the environment's lifecycle (e.g., a Docker container). If Docker is unavailable, the `runtime` executes commands locally. Each agent has its own `runtime` instance, ensuring isolation between tasks.
+## Default request flow
 
-* **`Model`**: The `Model` is an interface (protocol) that abstracts communication with a language model (LLM). The default implementation, `OpenAIModel`, interacts with OpenAI-compatible APIs. You can provide your own implementation to connect to different model backends.
+1. User message enters `Agent`.
+2. Agent updates history and sends context + tool schemas to model.
+3. Model returns text and/or tool calls.
+4. Agent executes tool calls through `Runtime`.
+5. Results are appended to history and displayed.
 
-* **`TaskManager`**: The `TaskManager` manages the execution of background tasks. When you use the `delegate_task` tool, the `TaskManager` creates a new `Agent` with its own `Runtime` to execute the task asynchronously. This allows the main agent to continue its work or monitor the subtask's progress.
+## Optional legacy layer
 
-## Request Flow
+A separate legacy layer still exists for delegated background tasks:
 
-1.  The user sends a message to the `Agent` via the CLI or API.
-2.  The `Agent` adds the user's message to the conversation history.
-3.  The `Agent` sends the complete history to the `Model`.
-4.  The `Model` returns a response, which can be a text message or a request to call one or more tools (`tool_calls`).
-5.  If it's a text message, the `Agent` displays it to the user.
-6.  If it's a tool call, the `Agent` invokes the corresponding function (e.g., `tools._bash`), passing the necessary arguments to the `Runtime`.
-7.  The `Runtime` executes the action (e.g., an `ls` command in the Docker container).
-8.  The result of the execution is returned to the `Agent`.
-9.  The `Agent` adds the tool's result to the history and typically calls the `Model` again so it can process the result and decide the next step, continuing the cycle until the task is completed (signaled by the `stop` tool).
+* `pygent.task_manager.TaskManager`
+* `pygent.task_tools.register_task_tools()`
+
+This layer is opt-in and not part of the default CLI flow.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,8 +13,6 @@ To start an interactive session, simply run `pygent` in your terminal. You can u
 * `--load <dir>`: Loads a snapshot of a previously saved environment, including the workspace, history, and environment variables.
 * `--confirm-bash`: Prompts for confirmation before executing any command with the `bash` tool. The command is shown in the terminal before asking for permission.
 * `--ban-cmd <command>`: Disables the execution of a specific command.
-* `--preset <name>`: Starts the session using one of the built-in presets
-  (`autonomous`, `assistant`, or `reviewer`).
 
 ## Internal Commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,76 +1,57 @@
 # Configuration
 
-This page summarises the environment variables that control Pygent.  They can be
-exported in your shell or set via a `.env` file before running the CLI.
+Pygent reads settings from environment variables and optionally from `pygent.toml`.
+
+## Core variables (recommended)
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `OPENAI_API_KEY` | API key for OpenAI or any compatible service. | – |
-| `OPENAI_BASE_URL` | Base URL for the API endpoint. | `https://api.openai.com/v1` |
-| `PYGENT_MODEL` | Model name used for requests. | `gpt-4.1-mini` |
-| `PYGENT_IMAGE` | Docker image used for sandboxed execution. | `python:3.12-slim` |
-| `PYGENT_USE_DOCKER` | Set to `0` to run commands locally. Otherwise the runtime will try to use Docker if available. | auto |
-| `PYGENT_MAX_TASKS` | Maximum number of delegated tasks that can run concurrently. | `3` |
-| `PYGENT_HISTORY_FILE` | Path to a JSON file where the conversation history is saved. | – |
-| `PYGENT_WORKSPACE` | Directory used to persist the workspace between sessions. | – |
-| `PYGENT_SNAPSHOT` | Load environment and history from the given directory on startup. | – |
-| `PYGENT_STEP_TIMEOUT` | Default time limit in seconds for each step when running delegated tasks. | – |
-| `PYGENT_TASK_TIMEOUT` | Default overall time limit in seconds for delegated tasks. | – |
-| `PYGENT_PERSONA_NAME` | Name of the main agent persona. | `Pygent` |
-| `PYGENT_PERSONA` | Description of the main agent persona. | "a sandboxed coding assistant." |
-| `PYGENT_TASK_PERSONAS` | List of personas for delegated agents separated by `os.pathsep`. | – |
-| `PYGENT_TASK_PERSONAS_JSON` | JSON array of persona objects with name and description for delegated agents. Overrides `PYGENT_TASK_PERSONAS` if set. | – |
-| `PYGENT_INIT_FILES` | List of files or directories copied into the workspace at startup, separated by `os.pathsep`. | – |
-| `PYGENT_BANNED_COMMANDS` | Commands that cannot be executed by the bash tool, separated by `os.pathsep`. | – |
-| `PYGENT_BANNED_APPS` | Applications that cannot appear in any command, separated by `os.pathsep`. | – |
-| `PYGENT_LOG_FILE` | Path to the CLI log file. | `workspace/cli.log` |
-| `PYGENT_CONFIRM_BASH` | Require confirmation before running bash commands (set to `0` to disable). When enabled, the command is displayed before prompting. | `1` |
+| `OPENAI_API_KEY` | API key for OpenAI or compatible provider. | – |
+| `OPENAI_BASE_URL` | Base URL for OpenAI-compatible API. | `https://api.openai.com/v1` |
+| `PYGENT_MODEL` | Model name used by the agent. | `gpt-4.1-mini` |
+| `PYGENT_USE_DOCKER` | Set `0` to force local execution. | auto |
+| `PYGENT_IMAGE` | Docker image for sandbox execution. | `python:3.12-slim` |
+| `PYGENT_HISTORY_FILE` | Persisted conversation history file. | – |
+| `PYGENT_WORKSPACE` | Persistent workspace directory. | – |
+| `PYGENT_SNAPSHOT` | Snapshot directory to load on startup. | – |
+| `PYGENT_LOG_FILE` | CLI log path. | `workspace/cli.log` |
+| `PYGENT_CONFIRM_BASH` | Require bash confirmation (`0` disables). | `1` |
+| `PYGENT_BANNED_COMMANDS` | Blocked commands (`os.pathsep` separated). | – |
+| `PYGENT_BANNED_APPS` | Blocked apps (`os.pathsep` separated). | – |
+| `PYGENT_INIT_FILES` | Files/dirs copied at startup (`os.pathsep` separated). | – |
+| `PYGENT_PERSONA_NAME` | Main persona name. | `Pygent` |
+| `PYGENT_PERSONA` | Main persona description. | `a sandboxed coding assistant.` |
 
-Instead of setting environment variables you can create a `pygent.toml` file in
-the current directory or in your home folder. Values defined there are loaded at
-startup if the corresponding variables are unset. Example:
+## Optional legacy multi-agent variables
+
+These only matter if you explicitly use `TaskManager` / `register_task_tools()`.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `PYGENT_MAX_TASKS` | Max concurrent delegated tasks. | `3` |
+| `PYGENT_STEP_TIMEOUT` | Per-step timeout for delegated tasks. | – |
+| `PYGENT_TASK_TIMEOUT` | Total timeout for delegated tasks. | – |
+| `PYGENT_TASK_PERSONAS` | Delegated personas (`os.pathsep` separated). | – |
+| `PYGENT_TASK_PERSONAS_JSON` | JSON array for delegated personas. | – |
+
+## `pygent.toml`
+
+You can define these keys in `pygent.toml`:
 
 ```toml
 persona_name = "FriendlyBot"
 persona = "a friendly bot"
-
-[[task_personas]]
-name = "tester"
-description = "runs tests"
-
-[[task_personas]]
-name = "developer"
-description = "implements features"
-
 initial_files = ["bootstrap.py"]
 ```
 
-The keys map to the environment variables of the same name.
-
-You can also specify a configuration file explicitly when launching the CLI:
+Then start with:
 
 ```bash
 pygent --config path/to/pygent.toml
 ```
-Environment variables can also be provided on the command line using
-the `-e` option:
+
+You can also pass env vars directly in CLI:
 
 ```bash
 pygent -e OPENAI_API_KEY=sk-... -e PYGENT_MODEL=gpt-4
 ```
-If you need additional setup logic execute a Python file with
-`--pyconfig config.py`.
-To resume from a saved snapshot pass `--load DIR` or set `PYGENT_SNAPSHOT`.
-
-A practical example is included in
-[`examples/sample_config.toml`](https://github.com/marianochaves/pygent/blob/main/examples/sample_config.toml)
-together with the script
-[`config_file_example.py`](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py), which delegates a testing task:
-
-```bash
-python examples/config_file_example.py
-```
-
-
-See [Getting Started](getting-started.md) for installation instructions and the
-[API Reference](api-reference.md) for details about the available classes.

--- a/docs/crew-style.md
+++ b/docs/crew-style.md
@@ -1,59 +1,16 @@
-# Multi-Agent Collaboration
+# Multi-Agent Collaboration (Legacy)
 
-Pygent can coordinate multiple agents in parallel using the `TaskManager` class. This approach resembles systems like Crew AI where tasks are distributed to specialised agents.
+> Legacy note: multi-agent orchestration is now optional and not the default product direction.
 
-## Defining personas
-
-Create a list of `Persona` objects representing the roles of the agents that will form the "crew":
+If you still need it, import directly from submodules:
 
 ```python
-from pygent import Agent, TaskManager
+from pygent import Agent
+from pygent.task_manager import TaskManager
 from pygent.persona import Persona
-
-personas = [
-    Persona("writer", "produces files"),
-    Persona("reviewer", "checks the result"),
-]
-
-manager = TaskManager(personas=personas)
 ```
 
-## Delegating tasks
+Then you can start background tasks with `TaskManager.start_task(...)`, monitor status,
+and collect files.
 
-Use `start_task` to launch background subtasks. Specify the desired persona and optionally send supporting files:
-
-```python
-main = Agent()
-
-# Send a writer agent to generate a file
-writing = manager.start_task(
-    "write_file path='note.txt' content='hi'\nstop",
-    main.runtime,
-    persona="writer",
-)
-
-# Another agent reads the file and prints it to the console
-reading = manager.start_task(
-    "bash cmd='cat note.txt'\nstop",
-    main.runtime,
-    files=["note.txt"],
-    persona="reviewer",
-)
-```
-
-## Monitoring and collecting results
-
-The `TaskManager` lets you check task status and copy files back to the main agent:
-
-```python
-import time
-for tid in [writing, reading]:
-    while manager.status(tid) == "running":
-        time.sleep(1)
-    print("Task status", tid + ":", manager.status(tid))
-
-print(manager.collect_file(main.runtime, writing, "note.txt"))
-main.runtime.cleanup()
-```
-
-With these calls you can build chained or parallel workflows, achieving behaviour similar to multi-agent frameworks like Crew AI.
+For most users, the recommended approach is the simpler single-agent CLI flow.

--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -1,10 +1,8 @@
 # Custom Models
 
-Pygent allows plugging in any model backend as long as it implements the `Model` protocol. This page collects extended examples showing how to build your own models, use the `openai_compat` helpers and return tool calls.
+Any object that implements `chat(messages, model, tools)` can be used as a model.
 
 ## Echo model
-
-A trivial example that simply repeats the last user message. The implementation returns an `openai_compat.Message` instance.
 
 ```python
 from pygent import Agent, openai_compat
@@ -18,9 +16,7 @@ ag = Agent(model=EchoModel())
 ag.step("test")
 ```
 
-## Calling a remote API with `openai_compat`
-
-The `openai_compat` module ships a lightweight client mirroring the official OpenAI interface. You can use it to talk to any compatible endpoint.
+## Calling OpenAI-compatible APIs
 
 ```python
 from pygent import Agent, openai_compat
@@ -39,11 +35,7 @@ ag = Agent(model=HTTPModel())
 ag.step("who am I?")
 ```
 
-Set `OPENAI_BASE_URL` and `OPENAI_API_KEY` to target a different provider if needed.
-
 ## Returning tool calls
-
-Custom models may trigger tools by returning a message with the `tool_calls` attribute populated. The next example runs the last user message as a `bash` command.
 
 ```python
 import json
@@ -61,14 +53,9 @@ class BashModel:
             ),
         )
         return openai_compat.Message(role="assistant", content=None, tool_calls=[call])
-
-ag = Agent(model=BashModel())
-ag.step("echo 'hi from tool'")
 ```
 
-## Global custom model
-
-Use `set_custom_model` to apply a model to all new agents and delegated tasks:
+## Global model override
 
 ```python
 from pygent import Agent
@@ -80,105 +67,7 @@ ag.step("hello")
 set_custom_model(None)
 ```
 
-## Delegating tasks from a custom model
+## Optional legacy delegated-task usage
 
-Models can call the `delegate_task` tool to start a background agent. This example delegates once and then stops.
-
-```python
-import json
-from pygent import Agent, openai_compat
-
-class DelegateModel:
-    def __init__(self):
-        self.first = True
-
-    def chat(self, messages, model, tools):
-        if self.first:
-            self.first = False
-            return openai_compat.Message(
-                role="assistant",
-                content=None,
-                tool_calls=[
-                    openai_compat.ToolCall(
-                        id="1",
-                        type="function",
-                        function=openai_compat.ToolCallFunction(
-                            name="delegate_task",
-                            arguments=json.dumps({"prompt": "noop"}),
-                        ),
-                    )
-                ],
-            )
-        return openai_compat.Message(role="assistant", content=None, tool_calls=[
-            openai_compat.ToolCall(
-                id="2",
-                type="function",
-                function=openai_compat.ToolCallFunction(name="stop", arguments="{}"),
-            )
-        ])
-
-ag = Agent(model=DelegateModel())
-ag.run_until_stop("begin", max_steps=2)
-```
-
-## Custom tool and external model in a delegated task
-
-This scenario combines several features: defining a new tool, using an
-OpenAI-compatible service via ``openai_compat`` and delegating work to a
-background agent.
-
-```python
-import json
-import time
-from pygent import Agent, TaskManager, register_tool, openai_compat
-
-def shout(rt, text: str) -> str:
-    return text.upper()
-
-register_tool(
-    "shout",
-    "Uppercase some text",
-    {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
-    shout,
-)
-
-class HTTPModel:
-    def chat(self, messages, model, tools):
-        resp = openai_compat.chat.completions.create(
-            model=model, messages=messages, tools=tools, tool_choice="auto"
-        )
-        return resp.choices[0].message
-
-class DelegatingModel:
-    def __init__(self):
-        self.done = False
-
-    def chat(self, messages, model, tools):
-        if not self.done:
-            self.done = True
-            return openai_compat.Message(
-                role="assistant",
-                content=None,
-                tool_calls=[
-                    openai_compat.ToolCall(
-                        id="1",
-                        type="function",
-                        function=openai_compat.ToolCallFunction(
-                            name="delegate_task",
-                            arguments=json.dumps({"prompt": "shout text='hi'\nstop"}),
-                        ),
-                    )
-                ],
-            )
-        return openai_compat.Message(role="assistant", content="delegated")
-
-manager = TaskManager(agent_factory=lambda p=None: Agent(model=HTTPModel(), persona=p))
-main = Agent(model=DelegatingModel())
-
-task_id = manager.start_task("begin", main.runtime)
-while manager.status(task_id) == "running":
-    time.sleep(1)
-print("Status:", manager.status(task_id))
-```
-
-These snippets demonstrate different ways of integrating custom logic with Pygent. See the [examples](examples.md) directory for the full source code.
+If you explicitly enable task tools, a custom model can call `delegate_task`.
+This is now considered an advanced legacy flow and is no longer the default direction.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,20 +1,29 @@
 # Examples
 
-This page collects small scripts demonstrating different aspects of Pygent. Each link points to the source file on GitHub.
+Small scripts demonstrating Pygent usage.
 
-- [api_example.py](https://github.com/marianochaves/pygent/blob/main/examples/api_example.py) &ndash; minimal use of the :class:`~pygent.agent.Agent` API.
-- [runtime_example.py](https://github.com/marianochaves/pygent/blob/main/examples/runtime_example.py) &ndash; using the :class:`~pygent.runtime.Runtime` class directly.
-- [write_file_demo.py](https://github.com/marianochaves/pygent/blob/main/examples/write_file_demo.py) &ndash; calling the built-in tools from Python code.
-- [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) &ndash; implementing a simple custom model.
-- [custom_model_with_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model_with_tool.py) &ndash; custom model issuing tool calls.
-- [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) &ndash; registering a custom tool.
-- [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py) &ndash; delegating work to a background agent.
-- [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) &ndash; loading a config file and delegating a testing agent.
-- [delegate_external_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_external_tool.py) &ndash; new tool using an external model service inside a delegated task.
-- [crew_example.py](https://github.com/marianochaves/pygent/blob/main/examples/crew_example.py) &ndash; coordenando dois agentes em paralelo.
-- [prompt_library.py](https://github.com/marianochaves/pygent/blob/main/examples/prompt_library.py) &ndash; using the prebuilt system message builders.
-- [agent_presets.py](https://github.com/marianochaves/pygent/blob/main/examples/agent_presets.py) &ndash; launching an agent from a preset.
+## Core examples
 
-See the [Custom Models](custom-models.md) page for a walkthrough of building your own models.
+- [api_example.py](https://github.com/marianochaves/pygent/blob/main/examples/api_example.py) — minimal `Agent` API.
+- [runtime_example.py](https://github.com/marianochaves/pygent/blob/main/examples/runtime_example.py) — direct `Runtime` usage.
+- [write_file_demo.py](https://github.com/marianochaves/pygent/blob/main/examples/write_file_demo.py) — built-in tools from Python.
+- [custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py) — basic custom model.
+- [custom_model_with_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model_with_tool.py) — custom model producing tool calls.
+- [custom_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_tool.py) — custom tool registration.
+- [config_file_example.py](https://github.com/marianochaves/pygent/blob/main/examples/config_file_example.py) — loading configuration from file.
+- [prompt_library.py](https://github.com/marianochaves/pygent/blob/main/examples/prompt_library.py) — switching prompt builders.
 
-Run these with `python <script>` from the project root. They expect the environment variables described in the [Configuration](configuration.md) page.
+## Optional legacy examples
+
+These demonstrate older multi-agent patterns that are no longer the default direction:
+
+- [delegate_task_example.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_task_example.py)
+- [delegate_external_tool.py](https://github.com/marianochaves/pygent/blob/main/examples/delegate_external_tool.py)
+- [crew_example.py](https://github.com/marianochaves/pygent/blob/main/examples/crew_example.py)
+- [agent_presets.py](https://github.com/marianochaves/pygent/blob/main/examples/agent_presets.py)
+
+Run with:
+
+```bash
+python examples/<script>.py
+```

--- a/docs/fastapi-server.md
+++ b/docs/fastapi-server.md
@@ -1,27 +1,13 @@
-# FastAPI Server
+# FastAPI Server (Legacy)
 
-Pygent can expose the `TaskManager` over HTTP using FastAPI. This optional server lets you create and monitor tasks remotely, mirroring the CLI workflow.
+> Legacy note: HTTP task orchestration is optional and outside the default CLI-first flow.
 
-Install the server dependencies with the `server` extra:
+If you still need server mode:
 
 ```bash
 pip install pygent[server]
-```
-
-Start the server with `uvicorn`:
-
-```bash
 uvicorn pygent.fastapi_app:create_app
 ```
 
-The API provides the following endpoints:
-
-* `POST /tasks` – start a new task. Payload fields match the arguments of `TaskManager.start_task`.
-* `GET /tasks` – list task IDs and their status.
-* `GET /tasks/{task_id}` – retrieve the status of a task.
-* `POST /tasks/{task_id}/message` – send a message to a finished task and get the reply. The response includes an optional `ask_user` field when the agent requires user input.
-* `GET /tasks/{task_id}/history` – fetch the conversation history for a task.
-
-You can view the full OpenAPI specification in your browser when the server is running at `/docs` or `/openapi.json`. The generated spec is also included in this repository as [`openapi.yaml`](openapi.yaml) for reference.
-
-Each task runs in the background just like tasks started with the CLI or the Python API. The server stores a `TaskManager` instance in `app.state.manager` so you can access it from middleware or custom routes if needed.
+The server exposes task endpoints backed by `TaskManager`.
+See `docs/openapi.yaml` for a reference schema.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,86 +1,52 @@
 # Getting Started
 
-Pygent is a minimalist coding assistant that runs shell commands inside a
-sandboxed environment. By default a Docker container is used, but if Docker
-is unavailable the commands run locally instead. This page shows how to install
-the package and gives a few examples covering the main features.
+Pygent is a simple agentic CLI for coding tasks.
+It executes commands in Docker when available, and locally when Docker is not available.
 
 ## Installation
-
-The recommended way to install Pygent is using pip:
 
 ```bash
 pip install pygent
 ```
 
-To include optional features like Docker support, the web UI, or the FastAPI server, you can specify extras:
+If you want Docker SDK integration:
 
 ```bash
-pip install pygent[docker,ui,server]
+pip install pygent[docker]
 ```
 
-Python 3.9 or newer is required. If Docker is not installed on your system, you should omit the `[docker]` extra; commands that would use Docker will then run on the host system instead. Docker itself needs to be installed separately if you wish to use containerized execution.
-
-For developers or those wanting the latest unreleased features, Pygent can also be installed from source:
+From source:
 
 ```bash
 pip install -e .
+# optional
+pip install -e .[docker]
 ```
-You can include extras like `[docker,ui,server]` when installing from source as well (e.g., `pip install -e .[docker,ui,server]`).
 
-## Interactive session
-
-Start an interactive session by running `pygent` in a terminal. Use the
-`--docker` flag to force container execution or `--no-docker` to run locally.
-The CLI prints the persona name and whether commands run `local` or in
-`Docker` when the session starts so you know which agent is active.
-At the beginning of each request, the assistant proposes a short plan for how it
-intends to solve the task and waits for your approval before executing any
-commands. This helps you keep control over the session.
+## First interactive session
 
 ```bash
-$ pygent --docker
-vc> echo "Hello"
+pygent
 ```
 
-Each message is executed in the sandbox and the output printed. Use `/exit`
-to leave the session. You can also launch a simple web interface with
-`pygent ui` (or the old `pygent-ui` script, requires the `ui` extra).
+Useful startup options:
 
-Use `/help` inside the CLI to list available commands or `/help <cmd>`
-for details. The helper shows `/cmd` to run a raw shell command,
-`/cp` to copy files into the workspace and `/new` to restart the
-conversation while keeping the current runtime.
-Use `/tools` to enable or disable specific tools on the fly.
-Pass `--no-confirm-bash` if you want to skip the default confirmation
-before running any `bash` command. When confirmation is enabled,
-the agent displays the command before asking for approval.
-You can toggle this behaviour at runtime with `/confirm-bash on|off`.
-Add `--ban-cmd NAME` to prevent certain commands entirely.
-The `/save DIR` command copies the workspace, the CLI log and relevant
-configuration for later use.  Resume the session with
-`pygent --load DIR`.
-Use `/banned` inside the CLI to list or modify the banned commands.
+* `--docker` / `--no-docker`
+* `--config path/to/pygent.toml`
+* `--cwd` (use current directory as workspace)
+* `--confirm-bash` / `--no-confirm-bash`
+* `--ban-cmd CMD` (repeatable)
+* `--load DIR` (resume snapshot)
 
-### Tool usage
+Inside the session:
 
-During the conversation the assistant can call several built-in tools. `bash`
-runs shell commands and `write_file` creates files inside the workspace. For
-example:
+* `/help` and `/help <cmd>`
+* `/cmd <command>`
+* `/cp <source> [destination]`
+* `/tools`, `/banned`, `/confirm-bash on|off`
+* `/save <dir>` and `/exit`
 
-```text
-vc> write_file path="hello.txt" content="Hello from Pygent"
-vc> bash cmd="cat hello.txt"
-```
-
-You can disable all built-in tools with `pygent.clear_tools()` or
-remove a specific one with `pygent.remove_tool("bash")`. Restore the
-defaults at any time using `pygent.reset_tools()`. The system prompt will
-update automatically to list the tools currently registered.
-
-## Using the API
-
-The same functionality is accessible programmatically via the `Agent` class:
+## Programmatic usage
 
 ```python
 from pygent import Agent
@@ -90,73 +56,9 @@ ag.step("echo 'Hello World'")
 ag.runtime.cleanup()
 ```
 
-See [api_example.py](https://github.com/marianochaves/pygent/blob/main/examples/api_example.py)
-for a complete script. Additional examples show how to implement a custom model
-and how to interact with the `Runtime` class directly.
+## Next steps
 
-## Configuration
-
-Pygent communicates with the model through an OpenAI‑compatible API. Export your
-API key before running the assistant. A full list of environment variables is
-available in the [Configuration](configuration.md) page.
-
-For full control you may pass a custom model implementation to `Agent`. The file
-[custom_model.py](https://github.com/marianochaves/pygent/blob/main/examples/custom_model.py)
-contains a minimal echo model example. A dedicated [Custom Models](custom-models.md)
-page expands on this topic with additional scenarios.
-
-## Additional examples
-
-Several scripts in the `examples/` directory showcase different parts of the
-package (see the dedicated [Examples](examples.md) page):
-
-- **api_example.py** &ndash; minimal use of the :class:`~pygent.agent.Agent` API.
-- **runtime_example.py** &ndash; running commands through the
-  :class:`~pygent.runtime.Runtime` class directly.
-- **write_file_demo.py** &ndash; calling the built-in tools from Python code.
-- **custom_model.py** &ndash; plugging in a custom model.
-
-Below is the custom model snippet for reference:
-
-```python
-from pygent import Agent, openai_compat
-
-class EchoModel:
-    def chat(self, messages, model, tools):
-        last = messages[-1]["content"]
-        return openai_compat.Message(role="assistant", content=f"Echo: {last}")
-
-ag = Agent(model=EchoModel())
-ag.step("test")
-ag.runtime.cleanup()
-```
-
-Custom models can also issue tool calls. The following model runs the last user
-message as a `bash` command:
-
-```python
-import json
-from pygent import Agent, openai_compat
-
-
-class BashModel:
-    def chat(self, messages, model, tools):
-        cmd = messages[-1]["content"]
-        call = openai_compat.ToolCall(
-            id="1",
-            type="function",
-            function=openai_compat.ToolCallFunction(
-                name="bash",
-                arguments=json.dumps({"cmd": cmd}),
-            ),
-        )
-        return openai_compat.Message(role="assistant", content=None, tool_calls=[call])
-
-
-ag = Agent(model=BashModel())
-ag.step("echo hi")
-ag.runtime.cleanup()
-```
-
-See the [API reference](api-reference.md) for the complete list of classes and
-configuration options.
+* Configuration variables: [Configuration](configuration.md)
+* Tool registry and custom tools: [Tools](tools.md)
+* Custom model integration: [Custom Models](custom-models.md)
+* Full API docs: [API Reference](api-reference.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,27 @@
 # Welcome to Pygent
 
-**Pygent** is a minimalist and powerful coding assistant designed to execute tasks in a secure and isolated environment. By default, it uses Docker containers to ensure commands are run safely, but it can also operate locally if Docker is unavailable.
+**Pygent** is a minimalist coding assistant focused on one core workflow:
+**an agentic CLI that can safely execute commands in an isolated workspace**.
 
-Whether you're looking to automate development tasks, generate code, or simply experiment with a secure AI assistant, Pygent offers the tools and flexibility you need.
+By default, Pygent tries to run commands in Docker. If Docker is unavailable,
+it falls back to local execution.
 
 ## Highlights
 
-* **Secure Execution**: Commands run in ephemeral Docker containers by default.
-* **Flexibility**: Integrates with language models compatible with the OpenAI API.
-* **Extensibility**: Create your own tools, customize system prompts, and extend the CLI with custom commands.
-* **Persistence**: Save and recover your workspace state between sessions.
-* **Dual Interface**: Use Pygent via an interactive CLI or a simple web interface.
+* **Simple default flow**: single-agent interactive CLI.
+* **Safe execution model**: isolated workspace and optional Docker runtime.
+* **OpenAI-compatible**: works with OpenAI and compatible providers.
+* **Extensible**: register custom tools and plug custom models.
+* **Stateful sessions**: history, snapshots, and reusable workspaces.
 
-## Where to start?
+## Start here
 
-* **New to Pygent?** Check out our **[Getting Started Guide](getting-started.md)** to install and run your first agent.
-* **Want to use the CLI?** The **[Command Line Interface (CLI)](cli.md)** page has all the details.
-* **Ready to customize?** Learn how to create **[Tools](tools.md)** and **[Custom Models](custom-models.md)**.
-* **Want to understand how it works?** The **[Architecture](architecture.md)** section provides an overview of the internal components.
+* New user? Read **[Getting Started](getting-started.md)**.
+* CLI details? Go to **[CLI](cli.md)**.
+* Want customization? See **[Tools](tools.md)** and **[Custom Models](custom-models.md)**.
+* Want internals? Read **[Architecture](architecture.md)**.
+
+## About legacy advanced features
+
+Older multi-agent/preset/server flows are still documented in **Optional Legacy Features**.
+They are no longer the default product direction.

--- a/docs/prompt-library.md
+++ b/docs/prompt-library.md
@@ -1,18 +1,14 @@
 # Prompt Library
 
-This page collects a few ready-made system message builders that you can use
-to quickly customise the agent's behaviour. They live in the
-:mod:`pygent.prompt_library` module and work with
-:func:`~pygent.set_system_message_builder`. The
-:mod:`pygent.agent_presets` module builds on top of these to offer ready-made
-agents with preset tool sets.
+`pygent.prompt_library` provides ready-made system-message builders for common styles.
+
+Use with `set_system_message_builder`:
 
 ```python
-from pygent import Agent, set_system_message_builder, PROMPT_BUILDERS
+from pygent import Agent, set_system_message_builder
+from pygent.prompt_library import PROMPT_BUILDERS
 
-# pick one of the predefined builders
 set_system_message_builder(PROMPT_BUILDERS["autonomous"])
-
 ag = Agent()
 ag.run_until_stop("echo hello")
 ```
@@ -21,9 +17,8 @@ Available builders:
 
 | Name | Description |
 | --- | --- |
-| ``autonomous`` | Operates autonomously in a computing environment without further user interaction. It inspects the environment first, performs the task step by step, tests the outcome and finishes with a final artefact or summary via ``stop``. |
-| ``assistant`` | Encourages interactive behaviour asking for clarifications. |
-| ``reviewer`` | Focuses on reviewing code and suggesting improvements. |
+| `autonomous` | Tries to execute tasks end-to-end with minimal user interaction. |
+| `assistant` | Interactive style that asks for clarification when needed. |
+| `reviewer` | Focused on code review and improvement suggestions. |
 
-These builders are also used by the presets in
-:mod:`pygent.agent_presets` which include sensible tool selections.
+These builders are independent and can be combined with your own tool strategy.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,65 +1,62 @@
 # Tools
 
-Tools are at the heart of Pygent's functionality, allowing the agent to interact with the file system, execute commands, and perform other actions.
+Tools are how the model performs actions in the workspace.
 
-## Native Tools
+## Built-in core tools
 
-Pygent comes with a set of essential tools ready to use:
+These are enabled by default:
 
-* **`bash`**: Executes a shell command in the execution environment (local or Docker).
-    * **Parameters**: `cmd` (string) - The command to be executed.
-* **`write_file`**: Creates or overwrites a file in the agent's workspace.
-    * **Parameters**: `path` (string), `content` (string).
-* **`stop`**: Stops the agent's autonomous execution loop. Useful for signaling the end of a task.
-* **`ask_user`**: Used to request a response or input from the user, continuing the conversation. When feasible, include an `options` list to present a short menu.
-* **`read_image`**: Returns a data URL for an image in the workspace, useful for vision models. The MIME type is detected from the file contents when the extension is unknown.
+* **`bash`**: run a shell command.
+  * params: `cmd: string`
+* **`write_file`**: create/overwrite files in workspace.
+  * params: `path: string`, `content: string`
+* **`read_image`**: read an image file and return a data URL.
+  * params: `path: string`
+* **`ask_user`**: request additional user input.
+* **`stop`**: signal the autonomous loop to stop.
 
-## Task Tools
+## Optional legacy task tools
 
-To manage subtasks and background agents, Pygent offers specific tools that are activated by registering with `register_task_tools()`:
+If you want delegated multi-agent flows, register them explicitly:
 
-* **`delegate_task`**: Creates a new background task with a new agent.
-    * **Parameters**: `prompt` (string), `files` (list of strings, optional), `persona` (string, optional), `timeout` (float, optional).
-* **`task_status`**: Checks the status of a delegated task.
-    * **Parameters**: `task_id` (string).
-* **`collect_file`**: Retrieves a file or directory from a delegated task to the main agent's workspace.
-    * **Parameters**: `task_id` (string), `path` (string), `dest` (string, optional).
-* **`list_personas`**: Returns the available personas for delegated tasks.
+```python
+from pygent.task_tools import register_task_tools
 
-## Creating Custom Tools
+register_task_tools()
+```
 
-You can easily extend Pygent with your own tools.
+Additional tools then become available:
 
-### Using `register_tool`
+* `delegate_task`
+* `delegate_persona_task`
+* `task_status`
+* `collect_file`
+* `list_personas`
+* `download_file`
 
-The most direct way to register a new tool is using the `register_tool` function.
+## Registering custom tools
 
 ```python
 from pygent import Agent, register_tool
 
-# The tool function always receives the runtime as the first argument
 def hello(rt, name: str) -> str:
     return f"Hello {name}!"
 
-# Register the tool
 register_tool(
-    "hello", # Tool name
-    "Greet by name", # Description
-    {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}, # Parameter schema
-    hello # The function to be called
+    "hello",
+    "Greet by name",
+    {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
+    hello,
 )
 
 ag = Agent()
-# Now the agent can use the 'hello' tool
 ag.step("hello name='world'")
-ag.runtime.cleanup()
 ```
 
-### Using the `@tool` decorator
-Alternatively, you can use the `@tool` decorator for a more concise registration:
+Decorator version:
 
 ```python
-from pygent import tool, Agent
+from pygent import Agent, tool
 
 @tool(
     name="goodbye",
@@ -68,8 +65,4 @@ from pygent import tool, Agent
 )
 def goodbye(rt, name: str) -> str:
     return f"Goodbye {name}!"
-
-ag = Agent()
-ag.step("goodbye name='world'")
-ag.runtime.cleanup()
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,12 +10,13 @@ nav:
   - Custom Models: custom-models.md
   - Custom System Message: custom-system-message.md
   - Prompt Library: prompt-library.md
-  - Agent Presets: agent-presets.md
-  - Multi-Agent Collaboration: crew-style.md
   - Architecture: architecture.md
-  - FastAPI Server: fastapi-server.md
   - Examples: examples.md
   - API Reference: api-reference.md
+  - Optional Legacy Features:
+    - Agent Presets (Legacy): agent-presets.md
+    - Multi-Agent Collaboration (Legacy): crew-style.md
+    - FastAPI Server (Legacy): fastapi-server.md
 theme:
   name: material
   language: en
@@ -45,18 +46,15 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [.]  # Look for modules in the current directory
+          paths: [.]
           options:
             show_root_heading: True
-            # show_source: True  # Disabled for now to address long lines
             members_order: source
             show_bases: True
             show_signature_annotations: True
-            # separate_signature: True # Disabled for now, might contribute to line length issues
             docstring_section_style: spacy
             merge_init_into_class: True
             show_if_no_docstring: True
-            # Options to potentially help with long lines and improve readability
-            line_length: 80 # Attempt to wrap lines
-            show_symbol_type_toc: True # Add symbol types to ToC for better navigation
-            annotations_path: brief # Use brief paths for annotations
+            line_length: 80
+            show_symbol_type_toc: True
+            annotations_path: brief

--- a/pygent/__init__.py
+++ b/pygent/__init__.py
@@ -30,14 +30,6 @@ from .session import Session, CliSession
 from .models import Model, OpenAIModel, set_custom_model  # noqa: E402,F401
 from .errors import PygentError, APIError  # noqa: E402,F401
 from .tools import register_tool, tool, clear_tools, reset_tools, remove_tool  # noqa: E402,F401
-from .task_manager import TaskManager  # noqa: E402,F401
-from .task_tools import register_task_tools  # noqa: E402,F401
-from .prompt_library import PROMPT_BUILDERS  # noqa: E402,F401
-from .agent_presets import AGENT_PRESETS, AgentPreset  # noqa: E402,F401
-try:  # optional dependency
-    from .fastapi_app import create_app  # noqa: E402,F401
-except Exception:  # pragma: no cover - optional
-    create_app = None  # type: ignore
 
 __all__ = [
     "Agent",
@@ -57,10 +49,4 @@ __all__ = [
     "clear_tools",
     "reset_tools",
     "remove_tool",
-    "TaskManager",
-    "register_task_tools",
-    "PROMPT_BUILDERS",
-    "AGENT_PRESETS",
-    "AgentPreset",
-    "create_app",
 ]

--- a/pygent/agent.py
+++ b/pygent/agent.py
@@ -1,47 +1,60 @@
-"""Orchestration layer: receives messages, calls the OpenAI-compatible backend and dispatches tools."""
+"""Orchestration layer: receives messages, calls the model, and dispatches tools."""
 
 import json
 import os
 import pathlib
-import uuid
 import time
-from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional, Callable
+from contextlib import nullcontext
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional
 
 from rich.console import Console
-from rich.panel import Panel
 from rich.markdown import Markdown
+from rich.panel import Panel
+
 try:
     from rich import __version__ as _rich_version  # noqa: F401
 except Exception:  # pragma: no cover - tests may stub out rich
     import rich as _rich
+
     if not hasattr(_rich, "__version__"):
         _rich.__version__ = "0"
     if not hasattr(_rich, "__file__"):
         _rich.__file__ = "rich-not-installed"
+
 try:
     from rich import box  # type: ignore
-except Exception:  # pragma: no cover - tests stub out rich
+except Exception:  # pragma: no cover - tests may stub out rich
     box = None
-from contextlib import nullcontext
+
 try:  # pragma: no cover - optional dependency
     import questionary  # type: ignore
 except Exception:  # pragma: no cover - used in tests without questionary
     questionary = None
 
-from .runtime import Runtime
-from . import tools, models, openai_compat
-from .session import CliSession
+from . import models, openai_compat, tools
 from .models import Model, OpenAIModel
 from .persona import Persona
+from .runtime import Runtime
+from .session import CliSession
 from .system_message import DEFAULT_PERSONA, build_system_msg
 
 DEFAULT_MODEL = os.getenv("PYGENT_MODEL", "gpt-4.1-mini")
 console = Console()
 
 
+def _safe_print(*args: Any, **kwargs: Any) -> None:
+    if console is not None and hasattr(console, "print"):
+        console.print(*args, **kwargs)
+
+
+def _status(message: str, spinner: str):
+    if console is not None and hasattr(console, "status"):
+        return console.status(message, spinner=spinner)
+    return nullcontext()
+
+
 def _default_model() -> Model:
-    """Return the global custom model or the default OpenAI model."""
     return models.CUSTOM_MODEL or OpenAIModel()
 
 
@@ -62,6 +75,7 @@ def _default_confirm_bash() -> bool:
 @dataclass
 class Agent:
     """Interactive assistant handling messages and tool execution."""
+
     runtime: Runtime = field(default_factory=Runtime)
     model: Model = field(default_factory=_default_model)
     model_name: str = DEFAULT_MODEL
@@ -76,37 +90,40 @@ class Agent:
     max_non_tool_replies: Optional[int] = None
 
     def __post_init__(self) -> None:
-        """Initialize defaults after dataclass construction."""
         self._log_fp = None
         if not self.system_msg:
             self.refresh_system_message()
-        if self.history_file and isinstance(self.history_file, (str, pathlib.Path)):
-            self.history_file = pathlib.Path(self.history_file)
-            if self.history_file.is_file():
-                try:
-                    with self.history_file.open("r", encoding="utf-8") as fh:
-                        data = json.load(fh)
-                except Exception:
-                    data = []
-                self.history = [
-                    openai_compat.parse_message(m) if isinstance(m, dict) else m
-                    for m in data
-                ]
+        self._restore_history_file()
         if not self.history:
             self.append_history({"role": "system", "content": self.system_msg})
+        self._init_log_file()
+
+    def _restore_history_file(self) -> None:
+        if not self.history_file or not isinstance(self.history_file, (str, pathlib.Path)):
+            return
+        self.history_file = pathlib.Path(self.history_file)
+        if not self.history_file.is_file():
+            return
+        try:
+            with self.history_file.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = []
+        self.history = [openai_compat.parse_message(m) if isinstance(m, dict) else m for m in data]
+
+    def _init_log_file(self) -> None:
         if self.log_file is None:
-            if hasattr(self.runtime, "base_dir"):
-                self.log_file = pathlib.Path(getattr(self.runtime, "base_dir")) / "cli.log"
-            else:
-                self.log_file = pathlib.Path("cli.log")
-        if isinstance(self.log_file, (str, pathlib.Path)):
-            self.log_file = pathlib.Path(self.log_file)
-            os.environ.setdefault("PYGENT_LOG_FILE", str(self.log_file))
-            self.log_file.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                self._log_fp = self.log_file.open("a", encoding="utf-8")
-            except Exception:
-                self._log_fp = None
+            base_dir = getattr(self.runtime, "base_dir", None)
+            self.log_file = pathlib.Path(base_dir) / "cli.log" if base_dir else pathlib.Path("cli.log")
+        if not isinstance(self.log_file, (str, pathlib.Path)):
+            return
+        self.log_file = pathlib.Path(self.log_file)
+        os.environ.setdefault("PYGENT_LOG_FILE", str(self.log_file))
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._log_fp = self.log_file.open("a", encoding="utf-8")
+        except Exception:
+            self._log_fp = None
 
     def _message_dict(self, msg: Any) -> Dict[str, Any]:
         if isinstance(msg, dict):
@@ -119,10 +136,11 @@ class Agent:
         raise TypeError(f"Unsupported message type: {type(msg)!r}")
 
     def _save_history(self) -> None:
-        if self.history_file:
-            self.history_file.parent.mkdir(parents=True, exist_ok=True)
-            with self.history_file.open("w", encoding="utf-8") as fh:
-                json.dump([self._message_dict(m) for m in self.history], fh)
+        if not self.history_file:
+            return
+        self.history_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.history_file.open("w", encoding="utf-8") as fh:
+            json.dump([self._message_dict(m) for m in self.history], fh)
 
     def append_history(self, msg: Any) -> None:
         self.history.append(msg)
@@ -135,15 +153,94 @@ class Agent:
                 pass
 
     def refresh_system_message(self) -> None:
-        """Update the system prompt based on the current tool registry."""
         if self.system_message_builder:
-            self.system_msg = self.system_message_builder(
-                self.persona, self.disabled_tools
-            )
+            self.system_msg = self.system_message_builder(self.persona, self.disabled_tools)
         else:
             self.system_msg = build_system_msg(self.persona, self.disabled_tools)
         if self.history and self.history[0].get("role") == "system":
             self.history[0]["content"] = self.system_msg
+
+    def _active_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            schema
+            for schema in tools.TOOL_SCHEMAS
+            if schema["function"]["name"] not in self.disabled_tools
+        ]
+
+    def _confirm_bash_call(self, call: openai_compat.ToolCall) -> bool:
+        if not (self.confirm_bash and call.function.name == "bash"):
+            return True
+        args = json.loads(call.function.arguments or "{}")
+        cmd = args.get("cmd", "")
+        _safe_print(
+            Panel(
+                f"$ {cmd}",
+                title=f"[bold yellow]{self.persona.name} pending bash[/]",
+                border_style="yellow",
+                box=box.HEAVY_HEAD if box else None,
+                title_align="left",
+            )
+        )
+        prompt = "Run this command?"
+        if questionary:
+            approved = questionary.confirm(prompt, default=True).ask()
+        elif console is not None and hasattr(console, "input"):  # pragma: no cover - fallback for tests
+            answer = console.input(f"{prompt} [Y/n]: ").lower()
+            approved = answer == "" or answer.startswith("y")
+        else:
+            approved = False
+        if approved:
+            return True
+
+        output = f"$ {cmd}\n[bold red]Aborted by user.[/]"
+        self.append_history({"role": "tool", "content": output, "tool_call_id": call.id})
+        _safe_print(
+            Panel(
+                output,
+                title=f"[bold red]{self.persona.name} tool:{call.function.name}[/]",
+                border_style="red",
+                box=box.ROUNDED if box else None,
+                title_align="left",
+            )
+        )
+        return False
+
+    def _display_tool_output(self, call: openai_compat.ToolCall, output: str) -> None:
+        if call.function.name in {"ask_user", "stop"}:
+            return
+
+        display_output = output
+        if call.function.name == "read_image" and output.startswith("data:image"):
+            try:
+                args = json.loads(call.function.arguments or "{}")
+                path = args.get("path", "<unknown>")
+                self.append_history(
+                    {
+                        "role": "user",
+                        "content": [{"type": "image_url", "image_url": {"url": output}}],
+                    }
+                )
+            except Exception:
+                path = "<unknown>"
+            display_output = f"returned data URL for {path}"
+
+        _safe_print(
+            Panel(
+                display_output,
+                title=f"[bold bright_blue]{self.persona.name} tool:{call.function.name}[/]",
+                border_style="bright_blue",
+                box=box.ROUNDED if box else None,
+                title_align="left",
+            )
+        )
+
+    def _execute_tool_call(self, call: openai_compat.ToolCall) -> None:
+        if not self._confirm_bash_call(call):
+            return
+        with _status(f"[green]Running {call.function.name}...", spinner="line"):
+            output = tools.execute_tool(call, self.runtime)
+        self.append_history({"role": "tool", "content": output, "tool_call_id": call.id})
+        self._display_tool_output(call, output)
 
     def step(self, user_msg: str = None, role: str = "user") -> openai_compat.Message:
         """Execute one round of interaction with the model."""
@@ -152,104 +249,19 @@ class Agent:
         if user_msg:
             self.append_history({"role": role, "content": user_msg})
 
-        status_cm = (
-            console.status("[bold cyan]Thinking...", spinner="dots")
-            if hasattr(console, "status")
-            else nullcontext()
-        )
-        schemas = [
-            s
-            for s in tools.TOOL_SCHEMAS
-            if s["function"]["name"] not in self.disabled_tools
-        ]
-        with status_cm:
-            assistant_raw = self.model.chat(
-                self.history, self.model_name, schemas
-            )
+        with _status("[bold cyan]Thinking...", spinner="dots"):
+            assistant_raw = self.model.chat(self.history, self.model_name, self._active_schemas())
+
         assistant_msg = openai_compat.parse_message(assistant_raw)
         self.append_history(assistant_msg)
 
         if assistant_msg.tool_calls:
             for call in assistant_msg.tool_calls:
-                if self.confirm_bash and call.function.name == "bash":
-                    args = json.loads(call.function.arguments or "{}")
-                    cmd = args.get("cmd", "")
-                    console.print(
-                        Panel(
-                            f"$ {cmd}",
-                            title=f"[bold yellow]{self.persona.name} pending bash[/]",
-                            border_style="yellow",
-                            box=box.HEAVY_HEAD if box else None,
-                            title_align="left",
-                        )
-                    )
-                    prompt = "Run this command?"
-                    if questionary:
-                        ok = questionary.confirm(prompt, default=True).ask()
-                    else:  # pragma: no cover - fallback for tests
-                        ok_input = console.input(f"{prompt} [Y/n]: ").lower()
-                        ok = ok_input == "" or ok_input.startswith("y")
-                    if not ok:
-                        output = f"$ {cmd}\n[bold red]Aborted by user.[/]"
-                        self.append_history({"role": "tool", "content": output, "tool_call_id": call.id})
-                        console.print(
-                            Panel(
-                                output,
-                                title=f"[bold red]{self.persona.name} tool:{call.function.name}[/]",
-                                border_style="red",
-                                box=box.ROUNDED if box else None,
-                                title_align="left",
-                            )
-                        )
-                        continue
-                status_cm = (
-                    console.status(
-                        f"[green]Running {call.function.name}...", spinner="line"
-                    )
-                    if hasattr(console, "status")
-                    else nullcontext()
-                )
-                with status_cm:
-                    output = tools.execute_tool(call, self.runtime)
-                self.append_history(
-                    {"role": "tool", "content": output, "tool_call_id": call.id}
-                )
-                if call.function.name not in {"ask_user", "stop"}:
-                    display_output = output
-                    if call.function.name == "read_image" and output.startswith("data:image"):
-                        try:
-                            args = json.loads(call.function.arguments or "{}")
-                            path = args.get("path", "<unknown>")
-                            self.append_history(
-                                {
-                                    "role": "user",
-                                    "content": [
-                                        {
-                                            "type": "image_url",
-                                            "image_url": {
-                                                "url": output
-                                            }
-                                        }
-                                    ]
-                                }
-                            )
-                        except Exception:
-                            path = "<unknown>"
-                        display_output = f"returned data URL for {path}"
-                    console.print(
-                        Panel(
-                            display_output,
-                            title=f"[bold bright_blue]{self.persona.name} tool:{call.function.name}[/]",
-                            border_style="bright_blue",
-                            box=box.ROUNDED if box else None,
-                            title_align="left",
-                        )
-                    )
+                self._execute_tool_call(call)
         else:
-            markdown_response = Markdown(assistant_msg.content or "") # Ensure content is not None
-            console.print(
+            _safe_print(
                 Panel(
-                    markdown_response,
+                    Markdown(assistant_msg.content or ""),
                     title=f"[bold green]{self.persona.name} replied[/]",
                     title_align="left",
                     border_style="green",
@@ -265,11 +277,7 @@ class Agent:
         step_timeout: Optional[float] = None,
         max_time: Optional[float] = None,
     ) -> Optional[openai_compat.Message]:
-        """Run steps until ``stop`` is called or limits are reached.
-
-        The agent also stops if it replies without using a tool more than
-        ``max_non_tool_replies`` times consecutively.
-        """
+        """Run steps until ``stop`` is called or limits are reached."""
 
         if step_timeout is None:
             env = os.getenv("PYGENT_STEP_TIMEOUT")
@@ -278,57 +286,46 @@ class Agent:
             env = os.getenv("PYGENT_TASK_TIMEOUT")
             max_time = float(env) if env else None
 
-        msg = user_msg
+        msg: Optional[str] = user_msg
         start = time.monotonic()
         self._timed_out = False
         last_msg = None
         non_tool_replies = 0
-        for _ in range(max_steps):
+
+        for idx in range(max_steps):
             if max_time is not None and time.monotonic() - start > max_time:
-                self.append_history(
-                    {"role": "system", "content": f"[timeout after {max_time}s]"}
-                )
+                self.append_history({"role": "system", "content": f"[timeout after {max_time}s]"})
                 self._timed_out = True
                 break
+
             step_start = time.monotonic()
-            if msg==user_msg:
-              role = 'user'
-            else:
-              role = 'system'
+            role = "user" if idx == 0 else "system"
             assistant_msg = self.step(msg, role=role)
             last_msg = assistant_msg
-            if (
-                step_timeout is not None
-                and time.monotonic() - step_start > step_timeout
-            ):
-                self.append_history(
-                    {"role": "system", "content": f"[timeout after {step_timeout}s]"}
-                )
+
+            if step_timeout is not None and time.monotonic() - step_start > step_timeout:
+                self.append_history({"role": "system", "content": f"[timeout after {step_timeout}s]"})
                 self._timed_out = True
                 break
+
             calls = assistant_msg.tool_calls or []
             if any(c.function.name in ("stop", "ask_user") for c in calls):
                 break
+
             if calls:
                 non_tool_replies = 0
             else:
                 non_tool_replies += 1
-                if (
-                    self.max_non_tool_replies is not None
-                    and non_tool_replies >= self.max_non_tool_replies
-                ):
+                if self.max_non_tool_replies is not None and non_tool_replies >= self.max_non_tool_replies:
                     self.append_history(
-                        {
-                            "role": "system",
-                            "content": "[stopped after too many non-tool replies]",
-                        }
+                        {"role": "system", "content": "[stopped after too many non-tool replies]"}
                     )
                     break
             msg = None
+
         return last_msg
 
     def close(self) -> None:
-        """Close any open resources."""
         if self._log_fp:
             try:
                 self._log_fp.close()
@@ -342,30 +339,13 @@ def run_interactive(
     disabled_tools: Optional[List[str]] = None,
     confirm_bash: Optional[bool] = None,
     banned_commands: Optional[List[str]] = None,
-    preset: Optional[str] = None,
 ) -> None:  # pragma: no cover
-    """Start an interactive session in the terminal.
+    """Start an interactive session in the terminal."""
 
-    Parameters
-    ----------
-    preset:
-        Name of a preset from :data:`pygent.agent_presets.AGENT_PRESETS` to use
-        when creating the agent.
-    """
     ws = pathlib.Path.cwd() / workspace_name if workspace_name else None
-    if preset:
-        from .agent_presets import AGENT_PRESETS
-
-        agent = AGENT_PRESETS[preset].create_agent(
-            runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
-            disabled_tools=disabled_tools or [],
-            confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
-        )
-    else:
-        agent = Agent(
-            runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
-            disabled_tools=disabled_tools or [],
-            confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
-        )
-    session = CliSession(agent)
-    session.run()
+    agent = Agent(
+        runtime=Runtime(use_docker=use_docker, workspace=ws, banned_commands=banned_commands),
+        disabled_tools=disabled_tools or [],
+        confirm_bash=bool(confirm_bash) if confirm_bash is not None else _default_confirm_bash(),
+    )
+    CliSession(agent).run()

--- a/pygent/cli.py
+++ b/pygent/cli.py
@@ -8,7 +8,6 @@ import os
 import typer
 
 from .config import load_config, run_py_config, load_snapshot
-from .agent_presets import AGENT_PRESETS
 
 
 app = typer.Typer(invoke_without_command=True, help="Pygent command line interface")
@@ -73,12 +72,6 @@ def main(
         help="command to ban (repeatable)",
         show_default=False,
     ),
-    preset: Optional[str] = typer.Option(
-        None,
-        "--preset",
-        help="start session using a predefined agent preset (autonomous, assistant, reviewer)",
-        show_default=False,
-    ),
 ) -> None:  # pragma: no cover - CLI wrapper
     """Start an interactive session when no subcommand is given."""
     load_config(config)
@@ -102,7 +95,6 @@ def main(
         "omit_tool": omit_tool or [],
         "confirm_bash": confirm_bash,
         "ban_cmd": ban_cmd or [],
-        "preset": preset,
     }
     if ctx.invoked_subcommand is None:
         from .agent import run_interactive
@@ -113,7 +105,6 @@ def main(
             disabled_tools=omit_tool or [],
             confirm_bash=confirm_bash,
             banned_commands=ban_cmd or [],
-            preset=preset,
         )
         raise typer.Exit()
 
@@ -143,4 +134,3 @@ def run() -> None:  # pragma: no cover
 
 
 main = run  # Backwards compatibility
-

--- a/pygent/task_tools.py
+++ b/pygent/task_tools.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Optional tools for background tasks and personas."""
 
 import json
-from typing import Optional, List
+from typing import Optional
 
 from .runtime import Runtime
 from .task_manager import TaskManager
@@ -19,15 +19,78 @@ def _get_manager() -> TaskManager:
     return _task_manager
 
 
+def get_task_manager() -> TaskManager:
+    """Return the lazily-created manager used by task tools."""
+    return _get_manager()
+
+
+def set_task_manager(manager: TaskManager) -> None:
+    """Override the manager instance (used by tests and integration layers)."""
+    global _task_manager
+    _task_manager = manager
+
+
 # ---- tool implementations ----
-from .tools import (
-    _delegate_task,
-    _delegate_persona_task,
-    _list_personas,
-    _task_status,
-    _collect_file,
-    _download_file,
-)
+from .tools import _download_file
+
+
+def _delegate_task(
+    rt: Runtime,
+    prompt: str,
+    files: Optional[list[str]] = None,
+    timeout: Optional[float] = None,
+    step_timeout: Optional[float] = None,
+    persona: Optional[str] = None,
+) -> str:
+    if getattr(rt, "task_depth", 0) >= 1:
+        return "error: delegation not allowed in sub-tasks"
+    try:
+        tid = _get_manager().start_task(
+            prompt,
+            parent_rt=rt,
+            files=files,
+            parent_depth=getattr(rt, "task_depth", 0),
+            step_timeout=step_timeout,
+            task_timeout=timeout,
+            persona=persona,
+        )
+    except RuntimeError as exc:
+        return str(exc)
+    return f"started {tid}"
+
+
+def _delegate_persona_task(
+    rt: Runtime,
+    prompt: str,
+    persona: str,
+    files: Optional[list[str]] = None,
+    timeout: Optional[float] = None,
+    step_timeout: Optional[float] = None,
+) -> str:
+    return _delegate_task(
+        rt,
+        prompt=prompt,
+        files=files,
+        timeout=timeout,
+        step_timeout=step_timeout,
+        persona=persona,
+    )
+
+
+def _list_personas(rt: Runtime) -> str:
+    personas = [
+        {"name": p.name, "description": p.description}
+        for p in _get_manager().personas
+    ]
+    return json.dumps(personas)
+
+
+def _task_status(rt: Runtime, task_id: str) -> str:
+    return _get_manager().status(task_id)
+
+
+def _collect_file(rt: Runtime, task_id: str, path: str, dest: Optional[str] = None) -> str:
+    return _get_manager().collect_file(rt, task_id, path, dest)
 
 
 def register_task_tools() -> None:

--- a/pygent/tools.py
+++ b/pygent/tools.py
@@ -9,21 +9,12 @@ from pathlib import Path
 from copy import deepcopy
 
 from .runtime import Runtime
-from .task_manager import TaskManager
-
-_task_manager: Optional[TaskManager] = None
-
-
-def _get_manager() -> TaskManager:
-    global _task_manager
-    if _task_manager is None:
-        _task_manager = TaskManager()
-    return _task_manager
 
 
 # ---- registry ----
 TOOLS: Dict[str, Callable[..., str]] = {}
 TOOL_SCHEMAS: List[Dict[str, Any]] = []
+_task_manager: Any = None
 
 
 def register_tool(
@@ -149,73 +140,55 @@ def _ask_user(
 ) -> str:  # pragma: no cover - side-effect free
     return "Continuing the conversation."
 
-
-
-
-def _delegate_task(
-    rt: Runtime,
-    prompt: str,
-    files: Optional[list[str]] = None,
-    timeout: Optional[float] = None,
-    step_timeout: Optional[float] = None,
-    persona: Optional[str] = None,
-) -> str:
-    if getattr(rt, "task_depth", 0) >= 1:
-        return "error: delegation not allowed in sub-tasks"
-    try:
-        tid = _get_manager().start_task(
-            prompt,
-            parent_rt=rt,
-            files=files,
-            parent_depth=getattr(rt, "task_depth", 0),
-            step_timeout=step_timeout,
-            task_timeout=timeout,
-            persona=persona,
-        )
-    except RuntimeError as exc:
-        return str(exc)
-    return f"started {tid}"
-
-
-def _delegate_persona_task(
-    rt: Runtime,
-    prompt: str,
-    persona: str,
-    files: Optional[list[str]] = None,
-    timeout: Optional[float] = None,
-    step_timeout: Optional[float] = None,
-) -> str:
-    return _delegate_task(
-        rt,
-        prompt=prompt,
-        files=files,
-        timeout=timeout,
-        step_timeout=step_timeout,
-        persona=persona,
-    )
-
-
-def _list_personas(rt: Runtime) -> str:
-    """Return JSON list of personas."""
-    personas = [
-        {"name": p.name, "description": p.description}
-        for p in _get_manager().personas
-    ]
-    return json.dumps(personas)
-
-
-def _task_status(rt: Runtime, task_id: str) -> str:
-    return _get_manager().status(task_id)
-
-
-def _collect_file(rt: Runtime, task_id: str, path: str, dest: Optional[str] = None) -> str:
-    """Retrieve a file or directory from a delegated task."""
-    return _get_manager().collect_file(rt, task_id, path, dest)
-
-
 def _download_file(rt: Runtime, path: str, binary: bool = False) -> str:
     """Return the contents of a file from the workspace."""
     return rt.read_file(path, binary=binary)
+
+
+# Legacy wrappers kept outside the default tool registry so the core package
+# stays focused on a single-agent CLI flow.
+def _sync_task_manager() -> None:
+    from . import task_tools
+
+    if _task_manager is not None:
+        task_tools.set_task_manager(_task_manager)
+    else:
+        globals()["_task_manager"] = task_tools.get_task_manager()
+
+
+def _delegate_task(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._delegate_task(*args, **kwargs)
+
+
+def _delegate_persona_task(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._delegate_persona_task(*args, **kwargs)
+
+
+def _list_personas(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._list_personas(*args, **kwargs)
+
+
+def _task_status(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._task_status(*args, **kwargs)
+
+
+def _collect_file(*args: Any, **kwargs: Any) -> str:
+    from . import task_tools
+
+    _sync_task_manager()
+    return task_tools._collect_file(*args, **kwargs)
 
 
 @tool(
@@ -272,4 +245,3 @@ def remove_tool(name: str) -> None:
         if func.get("name") == name:
             TOOL_SCHEMAS.pop(i)
             break
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pygent"
-version = "0.4.2"
+version = "1.0.0"
 description = "Pygent is a minimalist coding assistant that runs commands in a Docker container when available and falls back to local execution."
 readme = "README.md"
 authors = [ { name = "Mariano Chaves", email = "mchaves.software@gmail.com" } ]


### PR DESCRIPTION
### Motivation

- Simplify the default product flow to a single-agent, CLI-first experience and mark multi-agent/task orchestration as optional legacy functionality.
- Improve robustness and observability around history persistence, logging, and interactive confirmation for dangerous operations like `bash` calls.
- Decouple and modularize background task APIs so the core package remains focused on the single-agent path while preserving task features behind explicit registration.

### Description

- Update documentation and site navigation to label presets, crew/multi-agent flows, FastAPI server, and delegated-task examples as "Legacy" and move them under an "Optional Legacy Features" section.
- Refactor `Agent` to centralize history restoration and log initialization, extract tool execution and display logic into helper methods, add safe printing/status helpers, and improve `bash` confirmation handling with `questionary`/fallback prompts.
- Decouple task-related functionality by splitting logic between `pygent.task_tools` and `pygent.tools`, lazily creating and wiring a `TaskManager` only when `register_task_tools()` is used, and remove task-related top-level exports from `pygent.__init__` to avoid exposing legacy APIs by default.
- Simplify the CLI and interactive launch paths by removing preset plumbing and always creating a default `Agent` in `run_interactive`, and update `pyproject.toml` version to `1.0.0`.

### Testing

- Ran the test suite with `pytest` and all tests completed successfully.
- Performed a basic smoke-check of the interactive CLI entrypoint via `pygent` to ensure the refactored `Agent` and logging initialization do not crash on startup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea507fcf48321a56a8cfbf4a523ac)